### PR TITLE
Scope the reset-docker script to only delete CKAN-related containers

### DIFF
--- a/reset-docker.sh
+++ b/reset-docker.sh
@@ -1,10 +1,15 @@
 #!/usr/bin/env bash
+
 docker-compose -f docker-compose.dev.yml down
 
-docker rm $(docker ps -a -f status=exited -f status=created -q)
+docker ps -a -f status=exited -f status=created | grep docker-ckan | awk '{ print $1 }' | xargs docker rm 
+docker ps -a -f status=exited -f status=created | grep alphagov | awk '{ print $1 }' | xargs docker rm 
+docker ps -a -f status=exited -f status=created | grep solr | awk '{ print $1 }' | xargs docker rm 
+docker ps -a -f status=exited -f status=created | grep postgis | awk '{ print $1 }' | xargs docker rm 
+docker ps -a -f status=exited -f status=created | grep alpine | awk '{ print $1 }' | xargs docker rm 
 
-docker images -q |xargs docker rmi
-docker rmi $(docker images -f dangling=true -q)      
-docker rmi $(docker images -q)    
-
-docker image prune -a
+docker images | grep docker-ckan | awk '{ print $3 }' | xargs docker rmi
+docker images | grep alphagov | awk '{ print $3 }' | xargs docker rmi
+docker images | grep solr | awk '{ print $3 }' | xargs docker rmi
+docker images | grep postgis | awk '{ print $3 }' | xargs docker rmi
+docker images | grep alpine | awk '{ print $3 }' | xargs docker rmi


### PR DESCRIPTION
- Previously, this script would delete every Docker container, volume
  and image on your machine. This would be disastrous if you had
  govuk-docker containers set up for other GOV.UK apps because you'd
  have to set everything up from scratch, not just the CKAN stuff that
  you're working on now.
- This (slightly verbosely, there's probably an easier way) scope the
  removals to just the things that the CKAN project creates (tested with
  `./rebuild-docker.sh` and then `./reset-docker.sh`.