### PR TITLE
Add postdev dockerfile

### DIFF
--- a/alpine-geos/README.md
+++ b/alpine-geos/README.md
@@ -1,0 +1,7 @@
+## Packaging kentsang/alpine-geos
+
+docker save kentsang/alpine-geos:latest > image.tar
+
+docker load < image.tar
+
+docker push kentsang/alpine-geos:latest 

--- a/ckan-base/2.7/Dockerfile
+++ b/ckan-base/2.7/Dockerfile
@@ -1,5 +1,5 @@
 # FROM alpine:3.7
-FROM alpine-geos
+FROM kentsang/alpine-geos
 
 # Internals, you probably don't need to change these
 ENV APP_DIR=/srv/app

--- a/ckan-base/setup/production.ini
+++ b/ckan-base/setup/production.ini
@@ -14,7 +14,7 @@
 [DEFAULT]
 
 # WARNING: *THIS SETTING MUST BE SET TO FALSE ON A PRODUCTION ENVIRONMENT*
-debug = true
+debug = false
 
 [server:main]
 use = egg:Paste#http
@@ -99,7 +99,7 @@ ckan.plugins = datagovuk_publisher_form datagovuk datagovsg_s3_resources dcat ha
 
 # Harvesting settings
 ckan.harvest.mq.type = redis
-ckan.harvest.mq.hostname = 127.0.0.1
+ckan.harvest.mq.hostname = redis
 ckan.harvest.mq.port = 6379
 ckan.harvest.mq.redis_db = 1
 

--- a/ckan-dev/2.7/Dockerfile
+++ b/ckan-dev/2.7/Dockerfile
@@ -22,4 +22,4 @@ RUN mkdir /var/log/ckan
 
 COPY setup/start_ckan_development.sh ${APP_DIR}
 
-CMD ["/srv/app/start_ckan_development.sh"]
+# CMD ["/srv/app/start_ckan_development.sh"]

--- a/ckan-dev/setup/start_ckan_development.sh
+++ b/ckan-dev/setup/start_ckan_development.sh
@@ -57,7 +57,7 @@ paster --plugin=ckan config-tool $SRC_DIR/ckan/test-core.ini \
     "ckan.datstore.read_url = $TEST_CKAN_DATASTORE_READ_URL" \
     "ckan.site_url = ${TEST_CKAN_SITE_URL}" \
     "solr_url = $TEST_CKAN_SOLR_URL" \
-    "ckan.redis_url = $TEST_CKAN_REDIS_URL"
+    "ckan.redis.url = $TEST_CKAN_REDIS_URL"
 
 # Run the prerun script to init CKAN and create the default admin user
 python prerun.py

--- a/ckan-postdev/Dockerfile
+++ b/ckan-postdev/Dockerfile
@@ -7,6 +7,4 @@ ARG TZ
 RUN cp /usr/share/zoneinfo/$TZ /etc/localtime
 RUN echo $TZ > /etc/timezone
 
-COPY setup/setup_tests.sh ${APP_DIR}
-
-# CMD ["/srv/app/start_tests.sh"]
+COPY docker-entrypoint.d/* /docker-entrypoint.d/

--- a/ckan-postdev/Dockerfile
+++ b/ckan-postdev/Dockerfile
@@ -1,0 +1,12 @@
+FROM alphagov/ckan:latest
+
+MAINTAINER GDS <dgu@digital.cabinet-office.gov.uk>
+
+# Set timezone
+ARG TZ
+RUN cp /usr/share/zoneinfo/$TZ /etc/localtime
+RUN echo $TZ > /etc/timezone
+
+COPY setup/setup_tests.sh ${APP_DIR}
+
+# CMD ["/srv/app/start_tests.sh"]

--- a/ckan-postdev/docker-entrypoint.d/post_dev_tasks.sh
+++ b/ckan-postdev/docker-entrypoint.d/post_dev_tasks.sh
@@ -1,0 +1,7 @@
+# Add post dev tasks such as changing config settings
+
+# For example-
+
+# echo "Loading test settings into harvest test-core.ini"
+# paster --plugin=ckan config-tool $SRC_EXTENSIONS_DIR/ckanext-harvest/test-core.ini \
+#     "ckan.harvest.mq.hostname = $TEST_CKAN_REDIS_HOSTNAME"

--- a/ckan-postdev/setup/setup_tests.sh
+++ b/ckan-postdev/setup/setup_tests.sh
@@ -1,0 +1,5 @@
+# Update test-core.ini in harvest
+
+echo "Loading test settings into harvest test-core.ini"
+paster --plugin=ckan config-tool $SRC_EXTENSIONS_DIR/ckanext-harvest/test-core.ini \
+    "ckan.harvest.mq.hostname = $TEST_CKAN_REDIS_HOSTNAME"

--- a/ckan-postdev/setup/setup_tests.sh
+++ b/ckan-postdev/setup/setup_tests.sh
@@ -1,5 +1,0 @@
-# Update test-core.ini in harvest
-
-echo "Loading test settings into harvest test-core.ini"
-paster --plugin=ckan config-tool $SRC_EXTENSIONS_DIR/ckanext-harvest/test-core.ini \
-    "ckan.harvest.mq.hostname = $TEST_CKAN_REDIS_HOSTNAME"

--- a/ckan/Dockerfile.dev
+++ b/ckan/Dockerfile.dev
@@ -3,11 +3,6 @@ FROM alphagov/ckan-dev:2.7
 
 MAINTAINER Your Name Here <you@example.com>
 
-# Set timezone
-ARG TZ
-RUN cp /usr/share/zoneinfo/$TZ /etc/localtime
-RUN echo $TZ > /etc/timezone
-
 # Install any extensions needed by your CKAN instance
 # (Make sure to add the plugins to CKAN__PLUGINS in the .env file)
 
@@ -19,11 +14,11 @@ RUN which python && \
     pip install -r https://raw.githubusercontent.com/alphagov/ckanext-dcat/6253f296c6d1200465a3223710d076cd24e37834/requirements.txt && \
     pip install -e git+https://github.com/alphagov/ckanext-harvest.git@0ba5e11cc89c1560ab724bac42f84180bcfab019#egg=ckanext-harvest && \
     pip install -r https://raw.githubusercontent.com/alphagov/ckanext-harvest/0ba5e11cc89c1560ab724bac42f84180bcfab019/pip-requirements.txt && \
-#    pip install -e git+https://github.com/alphagov/ckanext-spatial.git@b86a7189577285169b0cb5ed93f145387debeec6#egg=ckanext-spatial && \
+    pip install -e git+https://github.com/alphagov/ckanext-spatial.git@b86a7189577285169b0cb5ed93f145387debeec6#egg=ckanext-spatial && \
     pip install -r https://raw.githubusercontent.com/alphagov/ckanext-spatial/b86a7189577285169b0cb5ed93f145387debeec6/pip-requirements.txt && \
     pip install -e git+https://github.com/alphagov/ckanext-s3-resources.git@81eb36fb51da5e216e9405a7ad64c4096881ca85#egg=ckanext-s3-resources && \
     pip install -r https://raw.githubusercontent.com/alphagov/ckanext-s3-resources/81eb36fb51da5e216e9405a7ad64c4096881ca85/requirements.txt && \
-#    pip install -e git://github.com/alphagov/ckanext-datagovuk.git@release_122#egg=ckanext-datagovuk && \
+    pip install -e git://github.com/alphagov/ckanext-datagovuk.git@release_122#egg=ckanext-datagovuk && \
     pip install -r https://raw.githubusercontent.com/alphagov/ckanext-datagovuk/release_155/requirements.txt
 
 # Clone the extension(s) your are writing for your own project in the `src` folder

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,29 +1,6 @@
 version: "3"
 
 services:
-  # ckan-dev:
-  #   build:
-  #     context: ckan/
-  #     dockerfile: Dockerfile.dev
-  #     args:
-  #       - TZ=${TZ}
-    # env_file:
-    #   - .env
-    # links:
-    #   - db
-    #   - solr
-    #   - redis
-    # ports:
-    #   - "0.0.0.0:${CKAN_PORT}:5000"
-    # volumes:
-    #   - ./src:/srv/app/src_extensions
-    #   - ckan_storage:/var/lib/ckan
-    #   - ./logs:/var/log/ckan
-    # depends_on: 
-    #   - db
-    #   - solr
-    #   - redis
-
   ckan-postdev:
     build:
       context: ckan-postdev/

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,10 +1,33 @@
 version: "3"
 
 services:
-  ckan-dev:
+  # ckan-dev:
+  #   build:
+  #     context: ckan/
+  #     dockerfile: Dockerfile.dev
+  #     args:
+  #       - TZ=${TZ}
+    # env_file:
+    #   - .env
+    # links:
+    #   - db
+    #   - solr
+    #   - redis
+    # ports:
+    #   - "0.0.0.0:${CKAN_PORT}:5000"
+    # volumes:
+    #   - ./src:/srv/app/src_extensions
+    #   - ckan_storage:/var/lib/ckan
+    #   - ./logs:/var/log/ckan
+    # depends_on: 
+    #   - db
+    #   - solr
+    #   - redis
+
+  ckan-postdev:
     build:
-      context: ckan/
-      dockerfile: Dockerfile.dev
+      context: ckan-postdev/
+      dockerfile: Dockerfile
       args:
         - TZ=${TZ}
     env_file:
@@ -23,6 +46,7 @@ services:
       - db
       - solr
       - redis
+    command: bash -c "/srv/app/start_ckan_development.sh"
 
   db:
     container_name: db

--- a/scripts/rebuild-ckan.sh
+++ b/scripts/rebuild-ckan.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-(cd alpine-geos && docker build -t alpine-geos .)
 (cd ckan-base && docker build -t alphagov/ckan-base:2.7 -f 2.7/Dockerfile .)
 (cd ckan-dev && docker build -t alphagov/ckan-dev:2.7 -f 2.7/Dockerfile .)
 (cd ckan && docker build -t alphagov/ckan:latest -f Dockerfile.dev .)

--- a/scripts/rebuild-ckan.sh
+++ b/scripts/rebuild-ckan.sh
@@ -3,5 +3,6 @@
 (cd alpine-geos && docker build -t alpine-geos .)
 (cd ckan-base && docker build -t alphagov/ckan-base:2.7 -f 2.7/Dockerfile .)
 (cd ckan-dev && docker build -t alphagov/ckan-dev:2.7 -f 2.7/Dockerfile .)
+(cd ckan && docker build -t alphagov/ckan:latest -f Dockerfile.dev .)
 
 docker-compose -f docker-compose.dev.yml build 


### PR DESCRIPTION
## What

Add a postdev Dockerfile to speed up dev cycle so that devs can test out changes to settings or apply scripts before moving the scripts to images that may require time to rebuild.

## Why

With the existing setup in docker-compose it wasn't easy to add changes to files without having to rebuild dependencies added in `Dockerfile.dev`, this meant that changes in settings could take more than 10 minutes to test out. 

Allowing additional tasks to be added without having to rebuild dependencies should speed up the dev cycle from 10 minutes plus to a few minutes.

## Reference 

https://trello.com/c/umPLLoMX/1543-improve-the-dev-cycle-in-docker-ckan