### PR TITLE
Fix dcat

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,8 +27,10 @@ CKAN_REDIS_URL=redis://redis:6379/1
 CKAN_DATAPUSHER_URL=http://datapusher:8800
 CKAN__DATAPUSHER__CALLBACK_URL_BASE=http://ckan:5000
 
+TEST_CKAN_SITE_URL=http://test.ckan.net
 TEST_CKAN_SOLR_URL=http://solr:8983/solr/ckan
 TEST_CKAN_REDIS_URL=redis://redis:6379/1
+TEST_CKAN_REDIS_HOSTNAME=redis
 
 # Core settings
 CKAN__STORAGE_PATH=/var/lib/ckan

--- a/README.md
+++ b/README.md
@@ -110,6 +110,20 @@ To run a container and be able to add a breakpoint with `pdb` or `ipdb`, run the
 This will start a new container, displaying the standard output in your terminal. If you add a breakpoint in a source file in the `src` folder (`import pdb; pdb.set_trace()`) you will be able to inspect it in this terminal next time the code is executed.
 
 
+### Running the remote debugger remote-pdb
+
+This is useful when debugging tests.
+
+Add the following line to the part of the code to set a breakpoint:
+
+    import remote_pdb; remote_pdb.set_trace(host='0.0.0.0', port=3000)
+
+After a remote pdb session is available, `RemotePdb session open at 0.0.0.0:3000`, then on another terminal connect to the debugger using `telnet`:
+
+    telnet localhost 3000
+
+You should now be connected to the debugger to start your investigations
+
 ## CKAN images
 
 ```

--- a/README.md
+++ b/README.md
@@ -88,9 +88,33 @@ to pass in args
 
 Run tests in `/srv/app/src_extensions/<ckanext directory>`
 
-Eg for `ckanext-harvest` navigate to `/srv/app/src_extensions/ckanext-harvest`
+#### ckanext-harvest
 
-    nosetests --ckan --with-pylons=test-core.ini ckanext/harvest/tests
+    cd /srv/app/src_extensions/ckanext-harvest ; nosetests --ckan  --nologcapture --with-pylons=test-core.ini ckanext/harvest/tests
+
+#### ckanext-spatial
+
+    cd /srv/app/src_extensions/ckanext-spatial ; nosetests --ckan --nologcapture --with-pylons=test.ini ckanext/spatial/tests
+
+#### ckanext-dcat
+
+    cd /srv/app/src_extensions/ckanext-dcat ; nosetests --ckan --nologcapture --with-pylons=test.ini ckanext/dcat/tests
+
+4 tests are failing -
+
+    cd /srv/app/src_extensions/ckanext-dcat ; nosetests --ckan --nologcapture --with-pylons=test.ini ckanext/dcat/tests/test_schemaorg_profile_serialize.py:TestSchemaOrgProfileSerializeDataset.test_graph_from_dataset
+
+    cd /srv/app/src_extensions/ckanext-dcat ; nosetests --ckan  --nologcapture --with-pylons=test.ini ckanext/dcat/tests/test_controllers.py:TestEndpoints.test_catalog_pagination
+
+    cd /srv/app/src_extensions/ckanext-dcat ; nosetests --ckan  --nologcapture --with-pylons=test.ini ckanext/dcat/tests/test_controllers.py:TestEndpoints.test_catalog_pagination_parameters
+
+    cd /srv/app/src_extensions/ckanext-dcat ; nosetests --ckan  --nologcapture --with-pylons=test.ini ckanext/dcat/tests/test_schemaorg_profile_serialize.py:TestSchemaOrgProfileSerializeDataset.test_graph_from_dataset
+
+    cd /srv/app/src_extensions/ckanext-dcat ; nosetests --ckan  --nologcapture --with-pylons=test.ini ckanext/dcat/tests/test_schemaorg_profile_serialize.py:TestSchemaOrgProfileSerializeDataset.test_groups
+
+These tests appear to be failing because it is picking up the `ckan.site_url` as localhost:5000 rather than the TEST_CKAN_SITE_URL value of `test.ckan.net`. There might be a test configuration setting to enable the test site url to be correctly picked up.
+
+Setting `ckan.site_url` to `http://test.ckan.net` fixes the issue but this needs the hosts file to be updated on your machine to work.
 
 ### Create an extension
 
@@ -146,7 +170,7 @@ You should now be connected to the debugger to start your investigations
 The Docker images used to build your CKAN project are located in the `ckan/` folder. There are two Docker files:
 
 * `Dockerfile`: this is based on `openknowledge/ckan-base` (with the `Dockerfile` on the `/ckan-base/<version>` folder), an image with CKAN with all its dependencies, properly configured and running on [uWSGI](https://uwsgi-docs.readthedocs.io/en/latest/) (production setup)
-* `Dockerfile.dev`: this is based on `openknowledge/ckan-dev` (with the `Dockerfile` on the `/ckan-dev/<version>` folder), wich extends `openknowledge/ckan-base` to include:
+* `Dockerfile.dev`: this is based on `openknowledge/ckan-dev` (with the `Dockerfile` on the `/ckan-dev/<version>` folder), which extends `openknowledge/ckan-base` to include:
 
   * Any extension cloned on the `src` folder will be installed in the CKAN container when booting up Docker Compose (`docker-compose up`). This includes installing any requirements listed in a `requirements.txt` (or `pip-requirements.txt`) file and running `python setup.py develop`.
   * The CKAN image used will development requirements needed to run the tests .

--- a/ckan-dev/setup/start_ckan_development.sh
+++ b/ckan-dev/setup/start_ckan_development.sh
@@ -55,7 +55,7 @@ paster --plugin=ckan config-tool $SRC_DIR/ckan/test-core.ini \
     "sqlalchemy.url = $TEST_CKAN_SQLALCHEMY_URL" \
     "ckan.datstore.write_url = $TEST_CKAN_DATASTORE_WRITE_URL" \
     "ckan.datstore.read_url = $TEST_CKAN_DATASTORE_READ_URL" \
-    "ckan.site_url = ${TEST_CKAN_SITE_URL}" \
+    "ckan.site_url = $TEST_CKAN_SITE_URL" \
     "solr_url = $TEST_CKAN_SOLR_URL" \
     "ckan.redis.url = $TEST_CKAN_REDIS_URL"
 

--- a/ckan-postdev/Dockerfile
+++ b/ckan-postdev/Dockerfile
@@ -7,4 +7,8 @@ ARG TZ
 RUN cp /usr/share/zoneinfo/$TZ /etc/localtime
 RUN echo $TZ > /etc/timezone
 
+RUN pip install remote-pdb
+
 COPY docker-entrypoint.d/* /docker-entrypoint.d/
+
+EXPOSE 3000

--- a/ckan-postdev/docker-entrypoint.d/post_dev_tasks.sh
+++ b/ckan-postdev/docker-entrypoint.d/post_dev_tasks.sh
@@ -1,5 +1,8 @@
 # Add post dev tasks such as changing config settings
 
+echo "================ post dev tasks ================"
+
 echo "Loading test settings into ckan test-core.ini"
 paster --plugin=ckan config-tool $SRC_DIR/ckan/test-core.ini \
-    "ckan.harvest.mq.hostname = $TEST_CKAN_REDIS_HOSTNAME"
+    "ckan.harvest.mq.hostname = $TEST_CKAN_REDIS_HOSTNAME" \
+    "ckanext.dcat.base_uri = $TEST_CKAN_SITE_URL"

--- a/ckan-postdev/docker-entrypoint.d/post_dev_tasks.sh
+++ b/ckan-postdev/docker-entrypoint.d/post_dev_tasks.sh
@@ -2,7 +2,6 @@
 
 echo "================ post dev tasks ================"
 
-echo "Loading test settings into ckan test-core.ini"
-paster --plugin=ckan config-tool $SRC_DIR/ckan/test-core.ini \
-    "ckan.harvest.mq.hostname = $TEST_CKAN_REDIS_HOSTNAME" \
-    "ckanext.dcat.base_uri = $TEST_CKAN_SITE_URL"
+# echo "Loading test settings into ckan test-core.ini"
+# paster --plugin=ckan config-tool $SRC_DIR/ckan/test-core.ini \
+#     "ckan.harvest.mq.hostname = $TEST_CKAN_REDIS_HOSTNAME"

--- a/ckan/docker-entrypoint.d/setup_harvest.sh
+++ b/ckan/docker-entrypoint.d/setup_harvest.sh
@@ -1,10 +1,14 @@
 #!/bin/bash
 
-echo "***** Set up Harvest"
+echo "Set up Harvest DB"
 
 paster --plugin=ckanext-harvest harvester initdb -c "$CKAN_INI"
 
-echo "***** Loading test settings into harvest test-core.ini"
+echo "Loading test settings into harvest test-core.ini"
 
 paster --plugin=ckan config-tool $SRC_EXTENSIONS_DIR/ckanext-harvest/test-core.ini \
     "use = config:$SRC_DIR/ckan/test-core.ini"
+
+echo "Loading test settings into ckan test-core.ini"
+paster --plugin=ckan config-tool $SRC_DIR/ckan/test-core.ini \
+    "ckan.harvest.mq.hostname = $TEST_CKAN_REDIS_HOSTNAME"

--- a/ckan/docker-entrypoint.d/setup_spatial.sh
+++ b/ckan/docker-entrypoint.d/setup_spatial.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-echo "***** Set up Postgres POSTGIS"
+echo "Set up Spatial DB"
 
 paster --plugin=ckanext-spatial spatial initdb -c "$CKAN_INI"

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -15,6 +15,7 @@ services:
       - redis
     ports:
       - "0.0.0.0:${CKAN_PORT}:5000"
+      - "0.0.0.0:3000:3000"
     volumes:
       - ./src:/srv/app/src_extensions
       - ckan_storage:/var/lib/ckan


### PR DESCRIPTION
## What

I've added some instructions on how to run debugging on docker, updated the README with instructions on how to run the tests and documented a number of failing tests which I believe are due to some sort of configuration issue in docker. The Vagrant dev stack running the same DCAT tests pass without any problems, so it appears that the test environment is not picking up the correct config settings. 

This shouldn't block us though as the error message thrown is clear that the server name is not matching so we can ignore the failed DCAT tests and is probably some kind of issue to do with how the tests are configured which will be looked at in another card.

## How to review

Follow the steps in building the stack and run the DCAT tests. 