### PR TITLE
Set client max body size to 20M not default of 1M

### DIFF
--- a/nginx/setup/ckan.conf
+++ b/nginx/setup/ckan.conf
@@ -3,6 +3,7 @@ server {
     listen [::]:80;
     server_name  localhost;
     access_log /var/log/nginx/access.log;
+    client_max_body_size 20M;
 
     location / {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
## What

The default of 1M is not big enough to upload organograms (test ones in datagovuk are 6M), setting it to 20M should allow standard organogram xls files to be uploaded.

