### PR TITLE
Improve dev turn around time when updating production.ini

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,10 @@ to pass in args
 
     ./scripts/reset-ckan.sh <image (postdev, ckan, dev, base)> <reset volumes (Yn)> <version (2.7, 2.8)>
 
+### Updating CKAN configuration, production.ini
+
+When you have to make changes to the CKAN config file, `production.ini`, update the `production.ini` file located in `ckan/setup` project to get a faster turn around time. Changing it on `ckan-base/setup` will increase the turn around time to more than 10 minutes rather than under 5 minutes within the `ckan` project. `production.ini` has been left in `ckan-base` because the Dockerfile in `ckan-base` has references to it.
+
 ### Running tests for extensions
 
 #### ckanext-harvest

--- a/ckan-base/2.7/Dockerfile
+++ b/ckan-base/2.7/Dockerfile
@@ -42,7 +42,7 @@ RUN apk add --no-cache tzdata \
         g++ \
         autoconf \
         automake \
-	libtool \
+        libtool \
         python-dev \
         libxml2-dev \
         libxslt-dev \
@@ -87,7 +87,6 @@ RUN mkdir -p $CKAN_STORAGE_PATH && \
     chown -R ckan:ckan $CKAN_STORAGE_PATH
 
 COPY setup ${APP_DIR}
-COPY setup/production.ini ${APP_DIR}/production.ini
 COPY setup/ckan_harvesting.conf /etc/supervisord.d/ckan_harvesting.conf
 COPY setup/supervisor.worker.conf /etc/supervisord.d/worker.conf
 COPY setup/uwsgi.conf /srv/app/uwsgi.conf

--- a/ckan/2.7/Dockerfile.dev
+++ b/ckan/2.7/Dockerfile.dev
@@ -67,3 +67,6 @@ RUN git clone --branch 2.4.0 https://github.com/geopython/pycsw.git && \
 # is available in SOLR otherwise the search query in ckan_pycsw.py will fail.
 # Once the issue to provide the harvest metadata in SOLR is fixed this cronjob can be removed.
 RUN echo "*/5 * * * * paster --plugin=ckan search-index rebuild -r -c $APP_DIR/production.ini" >> /etc/crontabs/root
+
+# CKAN configuration, modify production.ini in this project to avoid rebuilding ckan-base and ckan-dev projects
+COPY setup/production.ini $APP_DIR/production.ini

--- a/ckan/2.8/Dockerfile.dev
+++ b/ckan/2.8/Dockerfile.dev
@@ -67,3 +67,6 @@ RUN git clone  --branch 2.4.0 https://github.com/geopython/pycsw.git && \
 # is available in SOLR otherwise the search query in ckan_pycsw.py will fail.
 # Once the issue to provide the harvest metadata in SOLR is fixed this cronjob can be removed.
 RUN echo "*/5 * * * * paster --plugin=ckan search-index rebuild -r -c $APP_DIR/production.ini" >> /etc/crontabs/root
+
+# CKAN configuration, modify production.ini in this project to avoid rebuilding ckan-base and ckan-dev projects
+COPY setup/production.ini $APP_DIR/production.ini

--- a/ckan/setup/production.ini
+++ b/ckan/setup/production.ini
@@ -1,0 +1,244 @@
+#
+# CKAN - Pylons configuration
+#
+# These are some of the configuration options available for your CKAN
+# instance. Check the documentation in 'doc/configuration.rst' or at the
+# following URL for a description of what they do and the full list of
+# available options:
+#
+# http://docs.ckan.org/en/latest/maintaining/configuration.html
+#
+# The %(here)s variable will be replaced with the parent directory of this file
+#
+
+[DEFAULT]
+
+# WARNING: *THIS SETTING MUST BE SET TO FALSE ON A PRODUCTION ENVIRONMENT*
+debug = false
+
+[server:main]
+use = egg:Paste#http
+host = 0.0.0.0
+port = 5000
+
+[app:main]
+use = egg:ckan
+full_stack = true
+cache_dir = /tmp/%(ckan.site_id)s/
+beaker.session.key = ckan
+
+beaker.session.secret = 9EZiPwkeS+cZpqb0VDWrN+Q0M
+app_instance_uuid = fdee5057-84ad-4b96-804a-d8c2dc027721
+
+who.config_file = %(here)s/who.ini
+who.log_level = warning
+who.log_file = %(cache_dir)s/who_log.ini
+
+## Database Settings
+sqlalchemy.url = postgresql://ckan_default:pass@localhost/ckan_default
+
+#ckan.datastore.write_url = postgresql://ckan_default:pass@localhost/datastore_default
+#ckan.datastore.read_url = postgresql://datastore_default:pass@localhost/datastore_default
+
+# PostgreSQL' full-text search parameters
+ckan.datastore.default_fts_lang = english
+ckan.datastore.default_fts_index_method = gist
+
+## Site Settings
+
+#ckan.site_url = http://192.168.10.10
+ckan.site_url = http://localhost:5000
+ckan.use_pylons_response_cleanup_middleware = true
+
+## Authorization Settings
+
+ckan.auth.anon_create_dataset = false
+ckan.auth.create_unowned_dataset = false
+ckan.auth.create_dataset_if_not_in_organization = false
+ckan.auth.user_create_groups = false
+ckan.auth.user_create_organizations = true
+ckan.auth.user_delete_groups = false
+ckan.auth.user_delete_organizations = true
+ckan.auth.create_user_via_api = true
+ckan.auth.create_user_via_web = true
+ckan.auth.roles_that_cascade_to_sub_groups = admin
+
+## User Account Creation Setting
+ckan.valid_email_regexes = .gov.uk$ .nhs.uk$ .nhs.net$ .ac.uk$ .os.uk$ .mod.uk$ .police.uk$ .bl.uk$
+
+## Search Settings
+
+ckan.site_id = dgu
+solr_url = http://127.0.0.1:8983/solr
+
+## CORS Settings
+
+# If cors.origin_allow_all is true, all origins are allowed.
+# If false, the cors.origin_whitelist is used.
+ckan.cors.origin_allow_all = true
+# cors.origin_whitelist is a space separated list of allowed domains.
+# ckan.cors.origin_whitelist = http://example1.com http://example2.com
+
+
+## Plugins Settings
+
+# Note: Add ``datastore`` to enable the CKAN DataStore
+#       Add ``datapusher`` to enable DataPusher
+#       Add ``resource_proxy`` to enable resorce proxying and get around the
+#       same origin policy
+
+ckan.plugins = datagovuk_publisher_form datagovuk dcat harvest ckan_harvester dcat_rdf_harvester dcat_json_harvester dcat_json_interface spatial_metadata spatial_query spatial_harvest_metadata_api gemini_csw_harvester gemini_waf_harvester gemini_doc_harvester inventory_harvester
+
+# These are marked as legacy harvesters
+# gemini_csw_harvester gemini_doc_harvester gemini_waf_harvester
+
+# This needs fixing
+# inventory_harvester
+
+
+# Harvesting settings
+ckan.harvest.mq.type = redis
+ckan.harvest.mq.hostname = redis
+ckan.harvest.mq.port = 6379
+ckan.harvest.mq.redis_db = 1
+
+ckan.spatial.validator.profiles = iso19139eden,constraints-1.4,gemini2-1.3
+ckan.spatial.validator.reject = true
+
+# Define which views should be created by default
+# (plugins must be loaded in ckan.plugins)
+# ckan.views.default_views = image_view text_view recline_view
+
+## Front-End Settings
+ckan.site_title = dev.data.gov.uk
+ckan.site_description = Data publisher
+ckan.favicon = /images/icons/ckan.ico
+ckan.gravatar_default = identicon
+ckan.preview.direct = png jpg gif
+ckan.preview.loadable = html htm rdf+xml owl+xml xml n3 n-triples turtle plain atom csv tsv rss txt json
+ckan.display_timezone = server
+
+# package_hide_extras = for_search_index_only
+#package_edit_return_url = http://another.frontend/dataset/<NAME>
+#package_new_return_url = http://another.frontend/dataset/<NAME>
+#ckan.recaptcha.version = 1
+#ckan.recaptcha.publickey =
+#ckan.recaptcha.privatekey =
+#licenses_group_url = http://licenses.opendefinition.org/licenses/groups/ckan.json
+# ckan.template_footer_end =
+
+
+## Internationalisation Settings
+ckan.locale_default = en_GB
+ckan.locale_order = en_GB
+ckan.locales_offered = en_GB
+ckan.locales_filtered_out = en_US
+ckan.i18n_directory = /srv/app/src_extensions/ckanext-datagovuk/ckanext/datagovuk/
+
+## Feeds Settings
+
+ckan.feeds.authority_name =
+ckan.feeds.date =
+ckan.feeds.author_name =
+ckan.feeds.author_link =
+
+## Storage Settings
+
+ckan.storage_path = /var/lib/ckan
+ckan.max_resource_size = 50
+#ckan.max_image_size = 2
+
+## S3 Settngs
+ckan.datagovuk.s3_aws_access_key_id = xx
+ckan.datagovuk.s3_aws_secret_access_key = xx
+ckan.datagovuk.s3_bucket_name = xx
+ckan.datagovuk.s3_url_prefix = xx
+ckan.datagovuk.s3_aws_region_name = xx
+
+## Legacy route mappings
+#ckan.legacy_route_mappings = {"home":"home.index", "about": "home.about"}
+
+## GA Settings
+#googleanalytics.account = data.gov.uk
+#googleanalytics.id = UA-10855508-1
+#googleanalytics.token.filepath = /vagrant/src/ga_token
+#ga-report.bounce_url = /
+#ga-report.period = monthly
+
+## Datapusher settings
+
+# Make sure you have set up the DataStore
+
+#ckan.datapusher.formats = csv xls xlsx tsv application/csv application/vnd.ms-excel application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
+#ckan.datapusher.url = http://127.0.0.1:8800/
+
+# Resource Proxy settings
+# Preview size limit, default: 1MB
+#ckan.resource_proxy.max_file_size = 1048576
+# Size of chunks to read/write.
+#ckan.resource_proxy.chunk_size = 4096
+
+## Activity Streams Settings
+
+#ckan.activity_streams_enabled = true
+#ckan.activity_list_limit = 31
+#ckan.activity_streams_email_notifications = true
+#ckan.email_notifications_since = 2 days
+ckan.hide_activity_from_users = %(ckan.site_id)s
+
+
+## Email settings
+
+#email_to = you@yourdomain.com
+#error_email_from = paste@localhost
+smtp.server = localhost:1025
+smtp.starttls = False
+#smtp.user = your_username@gmail.com
+#smtp.password = your_password
+smtp.mail_from = no-reply@data.gov.uk
+
+
+## Logging configuration
+[loggers]
+keys = root, ckan, ckanext
+
+[handlers]
+keys = console, file
+; keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARNING
+handlers = console, file
+; handlers = console
+
+[logger_ckan]
+level = INFO
+handlers = console, file
+; handlers = console
+qualname = ckan
+propagate = 0
+
+[logger_ckanext]
+level = DEBUG
+handlers = console, file
+; handlers = console
+qualname = ckanext
+propagate = 0
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[handler_file]
+class = logging.handlers.RotatingFileHandler
+formatter = generic
+level = NOTSET
+args = ("/var/log/ckan/ckan.log", "a", 20000000, 9)
+
+[formatter_generic]
+format = %(asctime)s %(levelname)-5.5s [%(name)s] %(message)s


### PR DESCRIPTION
## What

This should make it possible to update the CKAN configuration and get a turnaround quickly, as updating production.ini in ckan-base causes a rebuild of that project and other projects that inherit from it. 

production.ini in ckan-base is kept because the ckan-base Dockerfile refers to it.

## Why

Should improve turn around times after changes from more than 10 mins to under 5 minutes.