### PR TITLE
Fix setup_pycsw to target pycsw database not ckan

### DIFF
--- a/ckan/docker-entrypoint.d/setup_pycsw.sh
+++ b/ckan/docker-entrypoint.d/setup_pycsw.sh
@@ -6,7 +6,7 @@ cd $SRC_EXTENSIONS_DIR/ckanext-spatial
 paster --plugin=ckanext-spatial ckan-pycsw setup -p $APP_DIR/pycsw.cfg
 
 echo "Update pycsw abstract index to allow for larger records"
-PGPASSWORD=ckan psql -h db -U ckan -c "DROP INDEX ix_records_abstract;CREATE INDEX ix_records_abstract ON records((md5(abstract)));"
+PGPASSWORD=ckan psql pycsw -h db -U ckan -c "DROP INDEX ix_records_abstract;CREATE INDEX ix_records_abstract ON records((md5(abstract)));"
 
 # run cronjob 
 crond -l 2 -L /var/log/ckan/cron.log


### PR DESCRIPTION
## What

It was attempting to run the script against ckan which meant that it was failing, this now targets pycsw so will work enabling larger datasets to be ingested into the csw database.