### PR TITLE
Add ckan 2.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ The site is configured via env vars (the base CKAN image loads [ckanext-envvars]
 
 ## Quick start
 
-Copy the included `.env.example` and rename it to `.env-2.7` (or substitute 2.7 with 2.8 if working with 2.8) to modify it depending on your own needs.
+Available CKAN stacks: 2.7 (default), 2.8 and 2.9
+
+Copy the included `.env.example` and rename it to `.env-2.7` (or substitute 2.7 with 2.8/2.9) to modify it depending on your own needs.
 
 Using the default values on the `.env.example` file will get you a working CKAN instance. There is a sysadmin user created by default with the values defined in `CKAN_SYSADMIN_NAME` and `CKAN_SYSADMIN_PASSWORD`(`ckan_admin` and `test1234` by default). I shouldn't be telling you this but obviously don't run any public CKAN instance with the default settings.
 
@@ -58,15 +60,15 @@ To develop local extensions use the `docker-compose.dev.yml` file:
 
 To setup your dev environment by cloning ckan and the extensions to your local src directory:
 
-    ./scripts/bootstrap.sh <version (default 2.7, 2.8)>
+    ./scripts/bootstrap.sh <version (default 2.7, 2.8, 2.9)>
 
 To build the images:
 
-    ./scripts/rebuild-ckan.sh <version (default 2.7, 2.8)> # If starting from new, the script will take at least 15 minutes to run.
+    ./scripts/rebuild-ckan.sh <version (default 2.7, 2.8, 2.9)> # If starting from new, the script will take at least 15 minutes to run.
 
 To start the containers:
 
-	./scripts/start-ckan.sh <version (default 2.7, 2.8)>
+	./scripts/start-ckan.sh <version (default 2.7, 2.8, 2.9)>
 
 See [CKAN Images](#ckan-images) for more details of what happens when using development mode.
 
@@ -101,6 +103,14 @@ When you have to make changes to the CKAN config file, `production.ini`, update 
 #### ckanext-harvest
 
     nosetests --ckan  --nologcapture --with-pylons=$SRC_EXTENSIONS_DIR/ckanext-harvest/test-core.ini ckanext.harvest
+
+##### NOTE - updating gather or fetch processes
+
+For the code to be picked up by supervisorctl, the process needs to be restarted 
+
+    supervisorctl restart ckan_fetch_consumer
+
+    supervisorctl restart ckan_gather_consumer
 
 #### ckanext-spatial
 
@@ -149,12 +159,14 @@ Add the following line to the part of the code to set a breakpoint:
 
     import remote_pdb; remote_pdb.set_trace(host='0.0.0.0', port=3000)
 
-Port 3000 is exposed for CKAN 2.7 stack, 3001 is available for CKAN 2.8
+Port 3000 is exposed for CKAN 2.7 stack, 3001 for 2.8, 3002 for 2.9
 The remote debug port can be found in the docker-compose file and should be unique for each stack.
 
 After a remote pdb session is available, `RemotePdb session open at 0.0.0.0:3000`, then on another terminal connect to the debugger using `telnet`:
 
     telnet localhost 3000
+
+NOTE - update the telnet port depending on the CKAN version you are running.
 
 You should now be connected to the debugger to start your investigations.
 
@@ -164,7 +176,7 @@ CKAN publisher:
   
   http://localhost:5000/
 
-Port 5000 is available for CKAN 2.7, 5001 is available for CKAN 2.8.
+Port 5000 is available for CKAN 2.7, 5001 for 2.8, 5002 for 2.9.
 The nginx port exposed can be found in the docker-compose file.
 
 CSW endpoint:
@@ -174,6 +186,8 @@ CSW endpoint:
 CSW summary:
 
   http://localhost:5000/csw?service=CSW&version=2.0.2&request=GetRecords&typenames=csw:Record&elementsetname=brief
+
+NOTE - update 5000 with the relevant port for the CKAN version you are running
 
 ## CKAN images
 

--- a/ckan-base/2.9/Dockerfile
+++ b/ckan-base/2.9/Dockerfile
@@ -1,0 +1,93 @@
+# FROM alpine:3.7
+FROM kentsang/alpine-geos
+
+# Internals, you probably don't need to change these
+ENV APP_DIR=/srv/app
+ENV SRC_DIR=/srv/app/src
+ENV CKAN_INI=${APP_DIR}/production.ini
+ENV TEST_CKAN_INI=${SRC_DIR}/ckan/test-core.ini
+ENV PIP_SRC=${SRC_DIR}
+ENV CKAN_STORAGE_PATH=/var/lib/ckan
+ENV GIT_URL=https://github.com/alphagov/ckan.git
+# CKAN version to build
+ENV GIT_BRANCH=ckan-2.9-dgu
+
+WORKDIR ${APP_DIR}
+
+# Install necessary packages to run CKAN
+RUN apk add --no-cache tzdata \
+        git \
+        gettext \
+        postgresql-client \
+        python \
+        apache2-utils \
+        libxml2 \
+        libxslt \
+        musl-dev \
+        uwsgi \
+        uwsgi-http \
+        uwsgi-corerouter \
+        uwsgi-python \
+        py2-gevent \
+        uwsgi-gevent \
+        libmagic \
+        curl \
+        vim \
+        sudo && \
+    # Packages to build CKAN requirements and plugins
+    apk add --no-cache --virtual .build-deps \
+        postgresql-dev \
+        gcc \
+        make \
+        g++ \
+        autoconf \
+        automake \
+	libtool \
+        python-dev \
+        libxml2-dev \
+        libxslt-dev \
+        linux-headers && \
+    # Create SRC_DIR
+    mkdir -p ${SRC_DIR} && \
+    # Install pip, supervisord and uwsgi
+    curl -o ${SRC_DIR}/get-pip.py https://bootstrap.pypa.io/get-pip.py && \
+    python ${SRC_DIR}/get-pip.py && \
+    pip install supervisor && \
+    mkdir /etc/supervisord.d && \
+    #pip wheel --wheel-dir=/wheels uwsgi gevent && \
+    rm -rf ${SRC_DIR}/get-pip.py
+
+# RUN echo "@testing http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories && \
+#     apk add --update --no-cache geos@testing geos-dev@testing
+
+COPY setup/supervisord.conf /etc
+
+# Install CKAN
+RUN pip install -e git+${GIT_URL}@${GIT_BRANCH}#egg=ckan && \
+    cd ${SRC_DIR}/ckan && \
+    cp who.ini ${APP_DIR} && \
+    pip install --no-binary :all: -r requirements-py2.txt && \
+    # Install CKAN envvars to support loading config from environment variables
+    pip install -e git+https://github.com/okfn/ckanext-envvars.git#egg=ckanext-envvars
+
+# Create a local user and group to run the app
+RUN addgroup -g 92 -S ckan && \
+    adduser -u 92 -h /srv/app -H -D -S -G ckan ckan
+
+# Create local storage folder
+RUN mkdir -p $CKAN_STORAGE_PATH && \
+    chown -R ckan:ckan $CKAN_STORAGE_PATH
+
+COPY setup ${APP_DIR}
+COPY setup/ckan_harvesting.conf /etc/supervisord.d/ckan_harvesting.conf
+COPY setup/supervisor.worker.conf /etc/supervisord.d/worker.conf
+COPY setup/uwsgi.conf /srv/app/uwsgi.conf
+
+# Create entrypoint directory for children image scripts
+ONBUILD RUN mkdir /docker-entrypoint.d
+
+RUN chown ckan -R /srv/app
+
+HEALTHCHECK --interval=10s --timeout=5s --retries=5 CMD curl --fail http://localhost:$CKAN_PORT/api/3/action/status_show || exit 1
+
+CMD ["/srv/app/start_ckan.sh"]

--- a/ckan-base/2.9/Dockerfile
+++ b/ckan-base/2.9/Dockerfile
@@ -42,7 +42,7 @@ RUN apk add --no-cache tzdata \
         g++ \
         autoconf \
         automake \
-	libtool \
+        libtool \
         python-dev \
         libxml2-dev \
         libxslt-dev \
@@ -79,6 +79,7 @@ RUN mkdir -p $CKAN_STORAGE_PATH && \
     chown -R ckan:ckan $CKAN_STORAGE_PATH
 
 COPY setup ${APP_DIR}
+COPY setup/prerun-2.9.py ${APP_DIR}/prerun.py
 COPY setup/ckan_harvesting.conf /etc/supervisord.d/ckan_harvesting.conf
 COPY setup/supervisor.worker.conf /etc/supervisord.d/worker.conf
 COPY setup/uwsgi.conf /srv/app/uwsgi.conf

--- a/ckan-base/setup/prerun-2.9.py
+++ b/ckan-base/setup/prerun-2.9.py
@@ -1,0 +1,153 @@
+import os
+import sys
+import subprocess
+import psycopg2
+import urllib2
+import time
+import re
+
+ckan_ini = os.environ.get('CKAN_INI', '/srv/app/production.ini')
+test_ckan_ini = os.environ.get('TEST_CKAN_INI', '/srv/app/src/test-core.ini')
+
+RETRY = 5
+
+def update_plugins():
+
+    plugins = os.environ.get('CKAN__PLUGINS', '')
+    print('[prerun] Setting the following plugins in {}:'.format(ckan_ini))
+    print(plugins)
+    cmd = ['ckan', 'config-tool',
+           ckan_ini, 'ckan.plugins = {}'.format(plugins)]
+    subprocess.check_output(cmd, stderr=subprocess.STDOUT)
+    print '[prerun] Plugins set.'
+
+    
+def check_main_db_connection(retry=None):
+
+    conn_str = os.environ.get('DEV_CKAN_SQLALCHEMY_URL')
+    if not conn_str:
+        print '[prerun] DEV_CKAN_SQLALCHEMY_URL not defined, not checking db'
+    return check_db_connection(conn_str, retry)
+
+
+def check_datastore_db_connection(retry=None):
+
+    conn_str = os.environ.get('CKAN_DATASTORE_WRITE_URL')
+    if not conn_str:
+        print '[prerun] CKAN_DATASTORE_WRITE_URL not defined, not checking db'
+    return check_db_connection(conn_str, retry)
+
+
+def check_db_connection(conn_str, retry=None):
+
+    if retry is None:
+        retry = RETRY
+    elif retry == 0:
+        print '[prerun] Giving up after 5 tries...'
+        sys.exit(1)
+
+    try:
+        connection = psycopg2.connect(conn_str)
+
+    except psycopg2.Error as e:
+        print str(e)
+        print '[prerun] Unable to connect to the database, waiting...'
+        time.sleep(10)
+        check_db_connection(conn_str, retry=retry - 1)
+    else:
+        connection.close()
+
+        
+def check_solr_connection(retry=None):
+
+    if retry is None:
+        retry = RETRY
+    elif retry == 0:
+        print '[prerun] Giving up after 5 tries...'
+        sys.exit(1)
+
+    url = os.environ.get('CKAN_SOLR_URL', '')
+    search_url = '{url}/select/?q=*&wt=json'.format(url=url)
+
+    try:
+        connection = urllib2.urlopen(search_url)
+    except urllib2.URLError as e:
+        print str(e)
+        print '[prerun] Unable to connect to solr, waiting...'
+        time.sleep(10)
+        check_solr_connection(retry=retry - 1)
+    else:
+        eval(connection.read())
+
+
+def init_db(ini=ckan_ini):
+
+    db_command = ['ckan', '-c', ini, 'db', 'init']
+    print '[prerun] Initializing or upgrading db - start: {}'.format(ini)
+    try:
+        subprocess.check_output(db_command, stderr=subprocess.STDOUT)
+        print '[prerun] Initializing or upgrading db - end'
+    except subprocess.CalledProcessError, e:
+        if 'OperationalError' in e.output:
+            print e.output
+            print '[prerun] Database not ready, waiting a bit before exit...'
+            time.sleep(5)
+            sys.exit(1)
+        else:
+            print e.output
+            raise e
+
+
+def create_sysadmin():
+
+    name = os.environ.get('CKAN_SYSADMIN_NAME')
+    password = os.environ.get('CKAN_SYSADMIN_PASSWORD')
+    email = os.environ.get('CKAN_SYSADMIN_EMAIL')
+
+    if name and password and email:
+
+        # Check if user exists
+        command = ['ckan', '-c', ckan_ini, 'user', name]
+
+        out = subprocess.check_output(command)
+        if 'User:None' not in re.sub(r'\s', '', out):
+            print '[prerun] Sysadmin user exists, skipping creation'
+            return
+
+        # Create user
+        command = [
+            'ckan', '-c', ckan_ini, 
+            'user', 'add',
+            name,
+            'password=' + password,
+            'email=' + email
+        ]
+
+        subprocess.call(command)
+        print '[prerun] Created user {0}'.format(name)
+
+        # Make it sysadmin
+        command = [
+            'ckan', '-c', ckan_ini,
+            'sysadmin', 'add',
+            name
+        ]
+
+        subprocess.call(command)
+        print '[prerun] Made user {0} a sysadmin'.format(name)
+
+
+if __name__ == '__main__':
+
+    maintenance = os.environ.get('MAINTENANCE_MODE', '').lower() == 'true'
+
+    if maintenance:
+        print '[prerun] Maintenance mode, skipping setup...'
+    else:
+        check_main_db_connection()
+        init_db()
+        init_db(ini=test_ckan_ini)
+        update_plugins()
+        check_datastore_db_connection()
+        check_solr_connection()
+        create_sysadmin()

--- a/ckan-dev/2.7/Dockerfile
+++ b/ckan-dev/2.7/Dockerfile
@@ -8,11 +8,16 @@ ENV GIT_BRANCH=ckan-2.7.6
 ENV SRC_EXTENSIONS_DIR=/srv/app/src_extensions
 
 # Install packages needed by the dev requirements
-RUN apk add --no-cache libffi-dev netcat-openbsd
+RUN apk add --no-cache libffi-dev
 
 # Install CKAN dev requirements
 RUN echo $GIT_BRANCH
 RUN pip install --no-binary :all: -r https://raw.githubusercontent.com/ckan/ckan/${GIT_BRANCH}/dev-requirements.txt
+
+# cryptography 2.9 is broken with this error message
+# ImportError: Error relocating /usr/lib/python2.7/site-packages/cryptography/hazmat/bindings/_openssl.so: RSA_get0_crt_params: symbol not found
+# so set to cryptography 2.8
+RUN pip install cryptography==2.8
 
 # Create folder for local extensions sources
 RUN mkdir $SRC_EXTENSIONS_DIR

--- a/ckan-dev/2.8/Dockerfile
+++ b/ckan-dev/2.8/Dockerfile
@@ -12,6 +12,11 @@ RUN apk add --no-cache libffi-dev
 # Install CKAN dev requirements
 RUN pip install --no-binary :all: -r https://raw.githubusercontent.com/ckan/ckan/${GIT_BRANCH}/dev-requirements.txt
 
+# cryptography 2.9 is broken with this error message
+# ImportError: Error relocating /usr/lib/python2.7/site-packages/cryptography/hazmat/bindings/_openssl.so: RSA_get0_crt_params: symbol not found
+# so set to cryptography 2.8
+RUN pip install cryptography==2.8
+
 # Create folder for local extensions sources
 RUN mkdir $SRC_EXTENSIONS_DIR
 

--- a/ckan-dev/2.9/Dockerfile
+++ b/ckan-dev/2.9/Dockerfile
@@ -1,0 +1,36 @@
+FROM alphagov/ckan-base:2.9
+
+MAINTAINER Open Knowledge International <info@okfn.org>
+
+ENV APP_DIR=/srv/app
+ENV SRC_EXTENSIONS_DIR=/srv/app/src_extensions
+
+# Install packages needed by the dev requirements
+RUN apk add --no-cache libffi-dev
+
+RUN pip install --upgrade pip
+
+# Install CKAN dev requirements
+# pip install is unable to install pytest-split-tests from dev-requirements.txt so install it manually
+RUN pip install pytest-split-tests==1.0.9
+
+RUN pip install --no-binary :all: -r https://raw.githubusercontent.com/alphagov/ckan/${GIT_BRANCH}/dev-requirements.txt
+
+RUN pip install configparser && \
+    ckan generate config ${CKAN_INI} && \
+    ckan config-tool ${CKAN_INI} 'ckan.plugins=${CKAN__PLUGINS}' && \
+    ckan config-tool ${CKAN_INI} 'ckan.site_url=${CKAN__SITE_URL}' && \
+    # Upgrade pylons version as the bundled version specified in requirements-py2.txt does not work
+    pip install Pylons==1.0.3 && \
+    # webob version installed is not high enough as lacks some dependencies
+    pip install webob==1.8.6
+
+# Create folder for local extensions sources
+RUN mkdir $SRC_EXTENSIONS_DIR
+
+# create folder for logs
+RUN mkdir /var/log/ckan
+
+COPY setup/start_ckan_development-2.9.sh ${APP_DIR}/start_ckan_development.sh
+
+# CMD ["/srv/app/start_ckan_development.sh"]

--- a/ckan-dev/2.9/Dockerfile
+++ b/ckan-dev/2.9/Dockerfile
@@ -18,12 +18,17 @@ RUN pip install --no-binary :all: -r https://raw.githubusercontent.com/alphagov/
 
 RUN pip install configparser && \
     ckan generate config ${CKAN_INI} && \
-    ckan config-tool ${CKAN_INI} 'ckan.plugins=${CKAN__PLUGINS}' && \
-    ckan config-tool ${CKAN_INI} 'ckan.site_url=${CKAN__SITE_URL}' && \
+    ckan config-tool ${CKAN_INI} "ckan.plugins=${CKAN__PLUGINS}" && \
+    ckan config-tool ${CKAN_INI} "ckan.site_url=${CKAN__SITE_URL}" 
+
     # Upgrade pylons version as the bundled version specified in requirements-py2.txt does not work
-    pip install Pylons==1.0.3 && \
+RUN pip install Pylons==1.0.3 && \
     # webob version installed is not high enough as lacks some dependencies
-    pip install webob==1.8.6
+    pip install webob==1.8.6 && \
+    # cryptography 2.9 is broken with this error message
+    # ImportError: Error relocating /usr/lib/python2.7/site-packages/cryptography/hazmat/bindings/_openssl.so: RSA_get0_crt_params: symbol not found
+    # so set to cryptography 2.8
+    pip install cryptography==2.8
 
 # Create folder for local extensions sources
 RUN mkdir $SRC_EXTENSIONS_DIR

--- a/ckan-dev/setup/start_ckan_development-2.9.sh
+++ b/ckan-dev/setup/start_ckan_development-2.9.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+
+# Install any local extensions in the src_extensions volume
+echo "Looking for local extensions to install..."
+echo "Extension dir contents:"
+ls -la $SRC_EXTENSIONS_DIR
+for i in $SRC_EXTENSIONS_DIR/*
+do
+    if [ -d $i ];
+    then
+
+        if [ -f $i/pip-requirements.txt ];
+        then
+            pip install -r $i/pip-requirements.txt
+            echo "Found requirements file in $i"
+        fi
+        if [ -f $i/requirements.txt ];
+        then
+            pip install -r $i/requirements.txt
+            echo "Found requirements file in $i"
+        fi
+        if [ -f $i/dev-requirements.txt ];
+        then
+            pip install -r $i/dev-requirements.txt
+            echo "Found dev-requirements file in $i"
+        fi
+        if [ -f $i/setup.py ];
+        then
+            cd $i
+            python $i/setup.py develop
+            echo "Found setup.py file in $i"
+            cd $APP_DIR
+        fi
+
+        # Point `use` in test.ini to location of `test-core.ini`
+        if [ -f $i/test.ini ];
+        then
+            echo "Updating \`test.ini\` reference to \`test-core.ini\` for plugin $i"
+            ckan config-tool $i/test.ini "use = config:../../src/ckan/test-core.ini"
+        fi
+    fi
+done
+
+# Set debug to true
+echo "Enabling debug mode"
+ckan config-tool $CKAN_INI -s DEFAULT "debug = true"
+
+# Update the plugins setting in the ini file with the values defined in the env var
+echo "Loading the following plugins: $CKAN__PLUGINS"
+ckan config-tool $CKAN_INI \
+    "sqlalchemy.url = $DEV_CKAN_SQLALCHEMY_URL" \
+    "ckan.site_url = $DEV_CKAN_SITE_URL" \
+    "solr_url = $DEV_CKAN_SOLR_URL" \
+    "ckan.redis.url = $DEV_CKAN_REDIS_URL" \
+    "ckan.site_url = $DEV_CKAN_SITE_URL" \
+    "ckan.plugins = $CKAN__PLUGINS"
+
+# Update test-core.ini DB, SOLR & Redis settings
+echo "Loading test settings into test-core.ini"
+ckan config-tool $SRC_DIR/ckan/test-core.ini \
+    "sqlalchemy.url = $TEST_CKAN_SQLALCHEMY_URL" \
+    "ckan.datstore.write_url = $TEST_CKAN_DATASTORE_WRITE_URL" \
+    "ckan.datstore.read_url = $TEST_CKAN_DATASTORE_READ_URL" \
+    "ckan.site_url = $TEST_CKAN_SITE_URL" \
+    "solr_url = $TEST_CKAN_SOLR_URL" \
+    "ckan.redis.url = $TEST_CKAN_REDIS_URL"
+
+ckan config-tool $APP_DIR/production.ini \
+  "ckan.datagovuk.s3_aws_access_key_id = $CKAN_S3_AWS_ACCESS_KEY_ID" \
+  "ckan.datagovuk.s3_aws_secret_access_key = $CKAN_S3_AWS_SECRET_ACCESS_KEY" \
+  "ckan.datagovuk.s3_bucket_name = $CKAN_S3_BUCKET_NAME" \
+  "ckan.datagovuk.s3_url_prefix = $CKAN_S3_URL_PREFIX" \
+  "ckan.datagovuk.s3_aws_region_name = $CKAN_S3_AWS_REGION_NAME"
+
+# Run the prerun script to init CKAN and create the default admin user
+python prerun.py
+
+# Run any startup scripts provided by images extending this one
+if [[ -d "/docker-entrypoint.d" ]]
+then
+    for f in /docker-entrypoint.d/*; do
+        case "$f" in
+            *.sh)     echo "$0: Running init file $f"; . "$f" ;;
+            *.py)     echo "$0: Running init file $f"; python "$f"; echo ;;
+            *)        echo "$0: Ignoring $f (not an sh or py file)" ;;
+        esac
+        echo
+    done
+fi
+
+if [[ $START_CKAN = 1 ]]; then
+    echo "Starting CKAN..."
+
+    # Start supervisord
+    ## commented out as ckan processes are not starting up
+    ## need to manually start the processes to see what errors there are
+    # supervisord --configuration /etc/supervisord.conf &
+
+    # Start the development server with automatic reload
+    ckan run --host 0.0.0.0 --reloader $CKAN_INI
+else
+    # just to keep container running
+    echo "Keeping container running..."
+    tail -f /dev/null
+fi

--- a/ckan-postdev/2.9/Dockerfile
+++ b/ckan-postdev/2.9/Dockerfile
@@ -1,11 +1,6 @@
-FROM alphagov/ckan:latest
+FROM alphagov/ckan:2.9
 
-MAINTAINER Data Gov UK <team@data.gov.uk>
-
-# Set timezone
-ARG TZ
-RUN cp /usr/share/zoneinfo/$TZ /etc/localtime
-RUN echo $TZ > /etc/timezone
+MAINTAINER Data Gov UK <team@data.gov.uk >
 
 RUN pip install remote-pdb
 

--- a/ckan/2.9/Dockerfile.dev
+++ b/ckan/2.9/Dockerfile.dev
@@ -12,7 +12,7 @@ RUN echo UTC > /etc/timezone
 ENV DCAT_SHA=8c55890e7bf9644460ae71470f37abbd9295c9fa
 ENV HARVEST_SHA=5507adc82585a273c51eaebdf7e1d3bbe7d0f9dc
 ENV SPATIAL_SHA=c35e1249cfb3c7b2f1286f433fd51c6fe8f05b72
-ENV DATAGOVUK_VERSION=release_165
+ENV DATAGOVUK_VERSION=ckan-2.9
 
 RUN which python && \
     pip install --upgrade setuptools && \

--- a/ckan/2.9/Dockerfile.dev
+++ b/ckan/2.9/Dockerfile.dev
@@ -1,0 +1,72 @@
+FROM alphagov/ckan-dev:2.9
+
+MAINTAINER Data Gov UK <team@data.gov.uk>
+
+# Set timezone
+RUN cp /usr/share/zoneinfo/UTC /etc/localtime
+RUN echo UTC > /etc/timezone
+
+# Install any extensions needed by your CKAN instance
+# (Make sure to add the plugins to CKAN__PLUGINS in the .env file)
+
+ENV DCAT_SHA=8c55890e7bf9644460ae71470f37abbd9295c9fa
+ENV HARVEST_SHA=5507adc82585a273c51eaebdf7e1d3bbe7d0f9dc
+ENV SPATIAL_SHA=c35e1249cfb3c7b2f1286f433fd51c6fe8f05b72
+ENV DATAGOVUK_VERSION=release_165
+
+RUN which python && \
+    pip install --upgrade setuptools && \
+    # install numpy outside of requirements.txt as was complaining of python 3.5 requirement
+    pip install numpy==1.16.4 && \
+    pip install -e git+https://github.com/alphagov/ckanext-dcat.git@$DCAT_SHA#egg=ckanext-dcat && \
+    pip install -r https://raw.githubusercontent.com/alphagov/ckanext-dcat/$DCAT_SHA/requirements.txt && \
+    pip install -e git+https://github.com/alphagov/ckanext-harvest.git@$HARVEST_SHA#egg=ckanext-harvest && \
+    pip install -r https://raw.githubusercontent.com/alphagov/ckanext-harvest/$HARVEST_SHA/pip-requirements.txt && \
+    pip install -e git+https://github.com/alphagov/ckanext-spatial.git@$SPATIAL_SHA#egg=ckanext-spatial && \
+    pip install -r https://raw.githubusercontent.com/alphagov/ckanext-spatial/$SPATIAL_SHA/pip-requirements.txt && \
+    pip install -e git://github.com/alphagov/ckanext-datagovuk.git@$DATAGOVUK_VERSION#egg=ckanext-datagovuk && \
+    pip install -r https://raw.githubusercontent.com/alphagov/ckanext-datagovuk/$DATAGOVUK_VERSION/requirements.txt
+
+# Clone the extension(s) your are writing for your own project in the `src` folder
+# to get them mounted in this image at runtime
+
+COPY docker-entrypoint.d/2.9/* /docker-entrypoint.d/
+
+# Apply any patches needed to CKAN core or any of the built extensions (not the
+# runtime mounted ones)
+# See https://github.com/okfn/docker-ckan#applying-patches
+COPY patches ${APP_DIR}/patches
+
+RUN for d in $APP_DIR/patches/*; do \
+        if [ -d $d ]; then \
+            for f in `ls $d/*.patch | sort -g`; do \
+                cd $SRC_DIR/`basename "$d"` && echo "$0: Applying patch $f to $SRC_DIR/`basename $d`"; patch -p1 < "$f" ; \
+            done ; \
+        fi ; \
+    done
+
+# Setup pycsw
+COPY setup/pycsw.cfg $APP_DIR/pycsw.cfg
+COPY setup/pycsw_supervisord.conf /etc/supervisord.d/pycsw_supervisord.conf
+
+ENV PYCSW_CONFIG=$APP_DIR/pycsw.cfg 
+
+WORKDIR $SRC_EXTENSIONS_DIR
+
+RUN git clone  --branch 2.4.0 https://github.com/geopython/pycsw.git && \
+    cd pycsw && \
+    pip install -e . && \
+    python setup.py build && \
+    python setup.py install && \
+    chown ckan $APP_DIR/pycsw.cfg && \
+    chmod 644 $APP_DIR/pycsw.cfg && \
+    echo "*/5 * * * * paster --plugin=ckanext-spatial ckan-pycsw load -p $APP_DIR/pycsw.cfg -u http://localhost:5000" > /etc/crontabs/root
+
+# Add cronjob to rebuild the SOLR search index.
+# This is the only way to guarantee that extras_harvest_object_id
+# is available in SOLR otherwise the search query in ckan_pycsw.py will fail.
+# Once the issue to provide the harvest metadata in SOLR is fixed this cronjob can be removed.
+RUN echo "*/5 * * * * paster --plugin=ckan search-index rebuild -r -c $APP_DIR/production.ini" >> /etc/crontabs/root
+
+# CKAN configuration, modify production.ini in this project to avoid rebuilding ckan-base and ckan-dev projects
+COPY setup/production.ini $APP_DIR/production.ini

--- a/ckan/docker-entrypoint.d/2.9/setup_datagovuk.sh
+++ b/ckan/docker-entrypoint.d/2.9/setup_datagovuk.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+echo "====== Set up Data.gov.uk ======"
+
+echo "Update datagovuk SQLAlchemy URL"
+ckan config-tool $SRC_EXTENSIONS_DIR/ckanext-datagovuk/test.ini \
+    "sqlalchemy.url = $TEST_CKAN_SQLALCHEMY_URL"

--- a/ckan/docker-entrypoint.d/2.9/setup_dcat.sh
+++ b/ckan/docker-entrypoint.d/2.9/setup_dcat.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+echo "====== Set up Dcat ======"
+
+echo "Update Dcat Solr URL"
+ckan config-tool $SRC_EXTENSIONS_DIR/ckanext-dcat/test.ini \
+    "solr_url = $TEST_CKAN_SOLR_URL"

--- a/ckan/docker-entrypoint.d/2.9/setup_harvest.sh
+++ b/ckan/docker-entrypoint.d/2.9/setup_harvest.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+echo "====== Set up Harvest ======"
+
+ckanext-harvest harvester initdb -c "$CKAN_INI"
+
+echo "Loading test settings into harvest test-core.ini"
+
+ckan config-tool $SRC_EXTENSIONS_DIR/ckanext-harvest/test-core.ini \
+    "use = config:$SRC_DIR/ckan/test-core.ini"
+
+echo "Loading test settings into ckan test-core.ini"
+ckan config-tool $SRC_DIR/ckan/test-core.ini \
+    "ckan.harvest.mq.hostname = $TEST_CKAN_REDIS_HOSTNAME"

--- a/ckan/docker-entrypoint.d/2.9/setup_pycsw.sh
+++ b/ckan/docker-entrypoint.d/2.9/setup_pycsw.sh
@@ -1,0 +1,12 @@
+# #!/bin/bash
+
+echo "====== set up pycsw ======"
+
+cd $SRC_EXTENSIONS_DIR/ckanext-spatial
+paster --plugin=ckanext-spatial ckan-pycsw setup -p $APP_DIR/pycsw.cfg
+
+echo "Update pycsw abstract index to allow for larger records"
+PGPASSWORD=ckan psql pycsw -h db -U ckan -c "DROP INDEX ix_records_abstract;CREATE INDEX ix_records_abstract ON records((md5(abstract)));"
+
+# run cronjob 
+crond -l 2 -L /var/log/ckan/cron.log

--- a/ckan/docker-entrypoint.d/2.9/setup_spatial.sh
+++ b/ckan/docker-entrypoint.d/2.9/setup_spatial.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+echo "====== Set up Spatial database ======"
+
+paster --plugin=ckanext-spatial spatial initdb -c "$CKAN_INI"
+
+PGPASSWORD=ckan psql -h db -U ckan -d ckan_test -c "CREATE EXTENSION IF NOT EXISTS postgis;"

--- a/docker-compose-2.9.yml
+++ b/docker-compose-2.9.yml
@@ -1,0 +1,84 @@
+version: "3"
+
+services:
+  ckan-postdev-2.9:
+    image: alphagov/ckan-postdev:2.9
+    build:
+      context: ckan-postdev/
+      dockerfile: 2.9/Dockerfile
+      args:
+        # set DISABLE_CRON to 1 to disable harvest & pycsw cronjobs (good idea when running tests)
+        - DISABLE_CRON=1
+        # set START_CKAN to 1 to start ckan and supervisord, 0 to prevent them from starting
+        # stopping ckan and background processes can be useful during development to investigate bugs
+        - START_CKAN=1
+    env_file:
+      - .env-2.9
+    links:
+      - db-2.9:db
+      - solr-2.9:solr
+      - redis-2.9:redis
+    ports:
+      - "0.0.0.0:3002:3000"
+    volumes:
+      - ./src/2.9:/srv/app/src_extensions
+      - ckan_storage-2.9:/var/lib/ckan
+      - ./logs/2.9:/var/log/ckan
+    depends_on: 
+      - db-2.9
+      - solr-2.9
+      - redis-2.9
+    command: bash -c "/srv/app/start_ckan_development.sh"
+    networks:
+      - ckan-2.9
+
+  db-2.9:
+    container_name: db-2.9
+    env_file:
+      - .env-2.9
+    build:
+      context: postgresql/
+    volumes:
+      - pg_data-2.9:/var/lib/postgresql/data
+    networks:
+      - ckan-2.9
+  
+  solr-2.9:
+    container_name: solr-2.9
+    build:
+      context: solr/
+    ports:
+      - "8985:8983"
+    volumes:
+      - solr_data-2.9:/opt/solr/server/solr/ckan/data/index
+    networks:
+      - ckan-2.9
+  
+  redis-2.9:
+    container_name: redis-2.9
+    image: redis:alpine
+    networks:
+      - ckan-2.9
+
+  nginx-2.9:
+    container_name: nginx-2.9
+    build:
+      context: nginx/
+      dockerfile: 2.9/Dockerfile
+    links:
+      - ckan-postdev-2.9
+    ports:
+      - 0.0.0.0:5002:80
+    volumes:
+      - ./logs/2.9:/var/log/nginx
+    networks:
+      - ckan-2.9
+  
+volumes:
+  ckan_storage-2.9:
+  pg_data-2.9:
+  solr_data-2.9:
+
+networks:
+  ckan-2.9:
+      driver: bridge

--- a/nginx/2.9/Dockerfile
+++ b/nginx/2.9/Dockerfile
@@ -1,0 +1,7 @@
+FROM nginx:stable-alpine
+
+RUN rm /etc/nginx/conf.d/default.conf
+
+COPY setup/ckan-2.9.conf /etc/nginx/conf.d
+
+EXPOSE 80/tcp

--- a/nginx/setup/ckan-2.9.conf
+++ b/nginx/setup/ckan-2.9.conf
@@ -1,0 +1,26 @@
+server {
+    listen       80;
+    listen [::]:80;
+    server_name  localhost;
+    access_log /var/log/nginx/access.log;
+    client_max_body_size 20M;
+
+    location / {
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Host $http_host;
+        proxy_redirect off;
+        proxy_pass http://ckan-postdev-2.9:5000/;
+    }
+
+    location /csw {
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Host $http_host;
+        proxy_redirect off;
+        proxy_pass http://ckan-postdev-2.9:8000/;
+    }
+
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+}

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,8 +1,15 @@
 #!/usr/bin/env bash
 
+# Default git fork
+CKAN_FORK=ckan
+
 if [[ ! -z $1 && $1 == '2.8' ]]; then
     CKAN_VERSION=2.8.3
     SRC_DIR=2.8
+elif [[ ! -z $1 && $1 == '2.9' ]]; then
+    CKAN_VERSION=2.9-dgu
+    CKAN_FORK=alphagov
+    SRC_DIR=2.9
 else
     CKAN_VERSION=2.7.6
     SRC_DIR=2.7
@@ -11,7 +18,7 @@ fi
 mkdir -p src/$SRC_DIR
 cd src/$SRC_DIR
 
-git clone --branch ckan-$CKAN_VERSION https://github.com/ckan/ckan
+git clone --branch ckan-$CKAN_VERSION https://github.com/$CKAN_FORK/ckan
 
 git clone https://github.com/alphagov/ckanext-datagovuk
 git clone --branch dgu-fixes https://github.com/alphagov/ckanext-harvest

--- a/scripts/rebuild-ckan.sh
+++ b/scripts/rebuild-ckan.sh
@@ -3,6 +3,9 @@
 if [[ ! -z $1 && $1 == '2.8' ]]; then
     echo "=== Building CKAN 2.8 ==="
     VERSION=2.8
+elif [[ ! -z $1 && $1 == '2.9' ]]; then
+    echo "=== Building CKAN 2.9 ==="
+    VERSION=2.9
 else
     echo "=== Building CKAN 2.7 ==="
     VERSION=2.7
@@ -13,4 +16,4 @@ fi
 (cd ckan && docker build -t alphagov/ckan:$VERSION -f $VERSION/Dockerfile.dev .)
 (cd ckan-postdev && docker build -t alphagov/ckan-postdev:$VERSION -f $VERSION/Dockerfile .)
 
-docker-compose -f docker-compose-$VERSION.yml build 
+docker-compose -f docker-compose-$VERSION.yml build

--- a/scripts/reset-ckan.sh
+++ b/scripts/reset-ckan.sh
@@ -2,6 +2,8 @@
 
 if [[ ! -z $3 && $3 == '2.8' ]]; then
     VERSION=2.8
+elif [[ ! -z $3 && $3 == '2.9' ]]; then
+    VERSION=2.9
 else
     VERSION=2.7
 fi

--- a/scripts/reset-volumes.sh
+++ b/scripts/reset-volumes.sh
@@ -2,6 +2,8 @@
 
 if [[ ! -z $1 && $1 == '2.8' ]]; then
     VERSION=-2.8
+elif [[ ! -z $1 && $1 == '2.9' ]]; then
+    VERSION=-2.9
 fi
 
 docker volume rm docker-ckan_ckan_storage$VERSION

--- a/scripts/start-ckan.sh
+++ b/scripts/start-ckan.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 if [[ ! -z $1 && $1 == '2.8' ]]; then
     VERSION=2.8
+elif [[ ! -z $1 && $1 == '2.9' ]]; then
+    VERSION=2.9
 else
     VERSION=2.7
 fi


### PR DESCRIPTION
## What

Add CKAN 2.9 stack for development, it is currently linked to https://github.com/alphagov/ckan/tree/ckan-2.9-dgu, which is a fork from CKAN because there are some parts of CKAN broken when running with python 2. 

The datagovuk extension has also had to be updated in order to work with core CKAN as some of the modules have been moved around which is needed for monkey patching - https://github.com/alphagov/ckanext-datagovuk/tree/ckan-2.9.

The landing page of CKAN appears to be working but there are lots of broken things which will be documented against a checklist, and at the moment cron jobs are not running to reduce noise caused by the number of errors.