### PR TITLE
Fix ckan 2.9

### DIFF
--- a/ckan-base/setup/prerun-2.9.py
+++ b/ckan-base/setup/prerun-2.9.py
@@ -30,14 +30,6 @@ def check_main_db_connection(retry=None):
     return check_db_connection(conn_str, retry)
 
 
-def check_datastore_db_connection(retry=None):
-
-    conn_str = os.environ.get('CKAN_DATASTORE_WRITE_URL')
-    if not conn_str:
-        print '[prerun] CKAN_DATASTORE_WRITE_URL not defined, not checking db'
-    return check_db_connection(conn_str, retry)
-
-
 def check_db_connection(conn_str, retry=None):
 
     if retry is None:
@@ -107,7 +99,7 @@ def create_sysadmin():
     if name and password and email:
 
         # Check if user exists
-        command = ['ckan', '-c', ckan_ini, 'user', name]
+        command = ['ckan', '-c', ckan_ini, 'user', 'show', name]
 
         out = subprocess.check_output(command)
         if 'User:None' not in re.sub(r'\s', '', out):
@@ -148,6 +140,5 @@ if __name__ == '__main__':
         init_db()
         init_db(ini=test_ckan_ini)
         update_plugins()
-        check_datastore_db_connection()
         check_solr_connection()
         create_sysadmin()

--- a/ckan/2.9/Dockerfile.dev
+++ b/ckan/2.9/Dockerfile.dev
@@ -69,4 +69,4 @@ RUN git clone  --branch 2.4.0 https://github.com/geopython/pycsw.git && \
 RUN echo "*/5 * * * * paster --plugin=ckan search-index rebuild -r -c $APP_DIR/production.ini" >> /etc/crontabs/root
 
 # CKAN configuration, modify production.ini in this project to avoid rebuilding ckan-base and ckan-dev projects
-COPY setup/production.ini $APP_DIR/production.ini
+COPY setup/production-2.9.ini $APP_DIR/production.ini

--- a/ckan/setup/production-2.9.ini
+++ b/ckan/setup/production-2.9.ini
@@ -1,0 +1,247 @@
+#
+# CKAN - Pylons configuration
+#
+# These are some of the configuration options available for your CKAN
+# instance. Check the documentation in 'doc/configuration.rst' or at the
+# following URL for a description of what they do and the full list of
+# available options:
+#
+# http://docs.ckan.org/en/latest/maintaining/configuration.html
+#
+# The %(here)s variable will be replaced with the parent directory of this file
+#
+
+[DEFAULT]
+
+# WARNING: *THIS SETTING MUST BE SET TO FALSE ON A PRODUCTION ENVIRONMENT*
+debug = false
+
+[server:main]
+use = egg:Paste#http
+host = 0.0.0.0
+port = 5000
+
+[app:main]
+use = egg:ckan
+full_stack = true
+cache_dir = /tmp/%(ckan.site_id)s/
+beaker.session.key = ckan
+
+beaker.session.secret = 9EZiPwkeS+cZpqb0VDWrN+Q0M
+app_instance_uuid = fdee5057-84ad-4b96-804a-d8c2dc027721
+
+who.config_file = %(here)s/who.ini
+who.log_level = warning
+who.log_file = %(cache_dir)s/who_log.ini
+
+## Database Settings
+sqlalchemy.url = postgresql://ckan_default:pass@localhost/ckan_default
+
+#ckan.datastore.write_url = postgresql://ckan_default:pass@localhost/datastore_default
+#ckan.datastore.read_url = postgresql://datastore_default:pass@localhost/datastore_default
+
+# PostgreSQL' full-text search parameters
+ckan.datastore.default_fts_lang = english
+ckan.datastore.default_fts_index_method = gist
+
+## Site Settings
+
+#ckan.site_url = http://192.168.10.10
+ckan.site_url = http://localhost:5000
+ckan.use_pylons_response_cleanup_middleware = true
+
+## Authorization Settings
+
+ckan.auth.anon_create_dataset = false
+ckan.auth.create_unowned_dataset = false
+ckan.auth.create_dataset_if_not_in_organization = false
+ckan.auth.user_create_groups = false
+ckan.auth.user_create_organizations = true
+ckan.auth.user_delete_groups = false
+ckan.auth.user_delete_organizations = true
+ckan.auth.create_user_via_api = true
+ckan.auth.create_user_via_web = true
+ckan.auth.roles_that_cascade_to_sub_groups = admin
+
+## User Account Creation Setting
+ckan.valid_email_regexes = .gov.uk$ .nhs.uk$ .nhs.net$ .ac.uk$ .os.uk$ .mod.uk$ .police.uk$ .bl.uk$
+
+## Search Settings
+
+ckan.site_id = dgu
+solr_url = http://127.0.0.1:8983/solr
+
+## CORS Settings
+
+# If cors.origin_allow_all is true, all origins are allowed.
+# If false, the cors.origin_whitelist is used.
+ckan.cors.origin_allow_all = true
+# cors.origin_whitelist is a space separated list of allowed domains.
+# ckan.cors.origin_whitelist = http://example1.com http://example2.com
+
+
+## Plugins Settings
+
+# Note: Add ``datastore`` to enable the CKAN DataStore
+#       Add ``datapusher`` to enable DataPusher
+#       Add ``resource_proxy`` to enable resorce proxying and get around the
+#       same origin policy
+
+ckan.plugins = datagovuk_publisher_form datagovuk dcat harvest ckan_harvester dcat_rdf_harvester dcat_json_harvester dcat_json_interface spatial_metadata spatial_query spatial_harvest_metadata_api gemini_csw_harvester gemini_waf_harvester gemini_doc_harvester inventory_harvester
+
+# These are marked as legacy harvesters
+# gemini_csw_harvester gemini_doc_harvester gemini_waf_harvester
+
+# This needs fixing
+# inventory_harvester
+
+
+# Harvesting settings
+ckan.harvest.mq.type = redis
+ckan.harvest.mq.hostname = redis
+ckan.harvest.mq.port = 6379
+ckan.harvest.mq.redis_db = 1
+
+ckan.spatial.validator.profiles = iso19139eden,constraints-1.4,gemini2-1.3
+ckan.spatial.validator.reject = true
+
+# Define which views should be created by default
+# (plugins must be loaded in ckan.plugins)
+# ckan.views.default_views = image_view text_view recline_view
+
+## Front-End Settings
+ckan.site_title = dev.data.gov.uk
+ckan.site_description = Data publisher
+ckan.favicon = /images/icons/ckan.ico
+ckan.gravatar_default = identicon
+ckan.preview.direct = png jpg gif
+ckan.preview.loadable = html htm rdf+xml owl+xml xml n3 n-triples turtle plain atom csv tsv rss txt json
+ckan.display_timezone = server
+
+# package_hide_extras = for_search_index_only
+#package_edit_return_url = http://another.frontend/dataset/<NAME>
+#package_new_return_url = http://another.frontend/dataset/<NAME>
+#ckan.recaptcha.version = 1
+#ckan.recaptcha.publickey =
+#ckan.recaptcha.privatekey =
+#licenses_group_url = http://licenses.opendefinition.org/licenses/groups/ckan.json
+# ckan.template_footer_end =
+
+
+## Internationalisation Settings
+ckan.locale_default = en_GB
+ckan.locale_order = en_GB
+ckan.locales_offered = en_GB
+ckan.locales_filtered_out = en_US
+ckan.i18n_directory = /srv/app/src_extensions/ckanext-datagovuk/ckanext/datagovuk/
+
+## Feeds Settings
+
+ckan.feeds.authority_name =
+ckan.feeds.date =
+ckan.feeds.author_name =
+ckan.feeds.author_link =
+
+## Storage Settings
+
+ckan.storage_path = /var/lib/ckan
+ckan.max_resource_size = 50
+#ckan.max_image_size = 2
+
+## S3 Settngs
+ckan.datagovuk.s3_aws_access_key_id = xx
+ckan.datagovuk.s3_aws_secret_access_key = xx
+ckan.datagovuk.s3_bucket_name = xx
+ckan.datagovuk.s3_url_prefix = xx
+ckan.datagovuk.s3_aws_region_name = xx
+
+## CKAN 2.9 settings
+ckan.route_after_login = dashboard.datasets
+
+## Legacy route mappings
+#ckan.legacy_route_mappings = {"home":"home.index", "about": "home.about"}
+
+## GA Settings
+#googleanalytics.account = data.gov.uk
+#googleanalytics.id = UA-10855508-1
+#googleanalytics.token.filepath = /vagrant/src/ga_token
+#ga-report.bounce_url = /
+#ga-report.period = monthly
+
+## Datapusher settings
+
+# Make sure you have set up the DataStore
+
+#ckan.datapusher.formats = csv xls xlsx tsv application/csv application/vnd.ms-excel application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
+#ckan.datapusher.url = http://127.0.0.1:8800/
+
+# Resource Proxy settings
+# Preview size limit, default: 1MB
+#ckan.resource_proxy.max_file_size = 1048576
+# Size of chunks to read/write.
+#ckan.resource_proxy.chunk_size = 4096
+
+## Activity Streams Settings
+
+#ckan.activity_streams_enabled = true
+#ckan.activity_list_limit = 31
+#ckan.activity_streams_email_notifications = true
+#ckan.email_notifications_since = 2 days
+ckan.hide_activity_from_users = %(ckan.site_id)s
+
+
+## Email settings
+
+#email_to = you@yourdomain.com
+#error_email_from = paste@localhost
+smtp.server = localhost:1025
+smtp.starttls = False
+#smtp.user = your_username@gmail.com
+#smtp.password = your_password
+smtp.mail_from = no-reply@data.gov.uk
+
+
+## Logging configuration
+[loggers]
+keys = root, ckan, ckanext
+
+[handlers]
+keys = console, file
+; keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARNING
+handlers = console, file
+; handlers = console
+
+[logger_ckan]
+level = INFO
+handlers = console, file
+; handlers = console
+qualname = ckan
+propagate = 0
+
+[logger_ckanext]
+level = DEBUG
+handlers = console, file
+; handlers = console
+qualname = ckanext
+propagate = 0
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[handler_file]
+class = logging.handlers.RotatingFileHandler
+formatter = generic
+level = NOTSET
+args = ("/var/log/ckan/ckan.log", "a", 20000000, 9)
+
+[formatter_generic]
+format = %(asctime)s %(levelname)-5.5s [%(name)s] %(message)s


### PR DESCRIPTION
## What

Removed the redundant script for datastores as we don't use that.
Also fixed the creation of sysadmin as it was failing due to a missing arg.

Introduced `ckan.route_after_login` to `production.ini` to redirect users to the datasets dashboard in line with how the existing CKAN publisher works.