### PR TITLE
add static-mock-harvest-source container

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,18 @@ ckan
 
 ```
 
+## Mock harvest source
+
+The docker compose configurations start an instance of the static [mock harvest source](https://github.com/alphagov/ckan-mock-harvest-sources)
+which should make it easy to populate the database with some basic standard content. To use this, add a harvest
+source with the address `http://static-mock-harvest-source:11088` and of type "CKAN". The content served by this
+harvest source is live modifiable from the `src/<version>/ckan-mock-harvest-sources/static/responses/` directory.
+
+For this harvest source to appear to work _completely_ right, you may need to add the hostname
+`static-mock-harvest-source` to your host machine's `/etc/hosts` file as an alias to `127.0.0.1`. This is because
+CKAN's web interface will link "directly" to the actual data files (and of course, it will be doing so using the
+hostname _it_ knows it by), so you have to do some tweaking of your host machine's configuration to allow your
+browser to resolve that address correctly.
 
 ## Known Issues
 

--- a/docker-compose-2.7.yml
+++ b/docker-compose-2.7.yml
@@ -28,6 +28,7 @@ services:
       - db
       - solr
       - redis
+      - static-mock-harvest-source
     command: bash -c "/srv/app/start_ckan_development.sh"
     networks:
       - ckan-2.7
@@ -73,7 +74,19 @@ services:
       - ./logs/2.7:/var/log/nginx
     networks:
       - ckan-2.7
-  
+
+  static-mock-harvest-source:
+    container_name: static-mock-harvest-source
+    build:
+      context: ./src/2.7/ckan-mock-harvest-sources/static/
+    ports:
+      - "11088:11088"
+    volumes:
+      - ./src/2.7/ckan-mock-harvest-sources/static/responses:/srv/responses
+      - ./src/2.7/ckan-mock-harvest-sources/static/mock-third-party:/src/mock-third-party
+    networks:
+      - ckan-2.7
+
 volumes:
   ckan_storage:
   pg_data:

--- a/docker-compose-2.8.yml
+++ b/docker-compose-2.8.yml
@@ -28,6 +28,7 @@ services:
       - db-2.8
       - solr-2.8
       - redis-2.8
+      - static-mock-harvest-source-2.8
     command: bash -c "/srv/app/start_ckan_development.sh"
     networks:
       - ckan-2.8
@@ -73,7 +74,19 @@ services:
       - ./logs/2.8:/var/log/nginx
     networks:
       - ckan-2.8
-  
+
+  static-mock-harvest-source-2.8:
+    container_name: static-mock-harvest-source-2.8
+    build:
+      context: ./src/2.8/ckan-mock-harvest-sources/static/
+    ports:
+      - "11088:11088"
+    volumes:
+      - ./src/2.8/ckan-mock-harvest-sources/static/responses:/srv/responses
+      - ./src/2.8/ckan-mock-harvest-sources/static/mock-third-party:/src/mock-third-party
+    networks:
+      - ckan-2.8
+
 volumes:
   ckan_storage-2.8:
   pg_data-2.8:

--- a/docker-compose-2.9.yml
+++ b/docker-compose-2.9.yml
@@ -28,6 +28,7 @@ services:
       - db-2.9
       - solr-2.9
       - redis-2.9
+      - static-mock-harvest-source-2.9
     command: bash -c "/srv/app/start_ckan_development.sh"
     networks:
       - ckan-2.9
@@ -73,7 +74,19 @@ services:
       - ./logs/2.9:/var/log/nginx
     networks:
       - ckan-2.9
-  
+
+  static-mock-harvest-source-2.9:
+    container_name: static-mock-harvest-source-2.9
+    build:
+      context: ./src/2.9/ckan-mock-harvest-sources/static/
+    ports:
+      - "11088:11088"
+    volumes:
+      - ./src/2.9/ckan-mock-harvest-sources/static/responses:/srv/responses
+      - ./src/2.9/ckan-mock-harvest-sources/static/mock-third-party:/src/mock-third-party
+    networks:
+      - ckan-2.9
+
 volumes:
   ckan_storage-2.9:
   pg_data-2.9:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -28,6 +28,7 @@ services:
       - db
       - solr
       - redis
+      - static-mock-harvest-source
     command: bash -c "/srv/app/start_ckan_development.sh"
 
   db:
@@ -62,6 +63,16 @@ services:
       - 0.0.0.0:5000:80
     volumes:
       - ./logs:/var/log/nginx
+
+  static-mock-harvest-source:
+    container_name: static-mock-harvest-source
+    build:
+      context: ./src/ckan-mock-harvest-sources/static/
+    ports:
+      - "11088:11088"
+    volumes:
+      - ./src/ckan-mock-harvest-sources/static/responses:/srv/responses
+      - ./src/ckan-mock-harvest-sources/static/mock-third-party:/src/mock-third-party
 
 volumes:
   ckan_storage:

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -16,8 +16,7 @@ else
 fi
 
 mkdir -p src/$SRC_DIR
-cd src/$SRC_DIR
-
+pushd src/$SRC_DIR
 git clone --branch ckan-$CKAN_VERSION https://github.com/$CKAN_FORK/ckan
 
 git clone https://github.com/alphagov/ckanext-datagovuk
@@ -25,3 +24,8 @@ git clone https://github.com/alphagov/ckanext-harvest
 git clone --branch dgu-fixes https://github.com/alphagov/ckanext-spatial
 git clone https://github.com/ckan/ckanext-dcat
 git clone https://github.com/geopython/pycsw.git --branch 2.4.0 
+
+git clone https://github.com/alphagov/ckan-mock-harvest-sources.git
+# appending this should quietly override any prior settings of the variable
+echo $'\nmap $host $mock_absolute_root_url { default "http://static-mock-harvest-source:11088/"; }' >> ckan-mock-harvest-sources/static/vars.conf
+popd


### PR DESCRIPTION
https://trello.com/c/DidXW0Xv

Include README.md note documenting its use and behaviour.

Ended up going with `static-mock-harvest-source` as the internally-used hostname, a developer can make direct web links work by adding this as an alias in their `/etc/hosts` file. It'll have to do.