### PR TITLE
Update bootstrap credentials for ckan 2.8

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -4,7 +4,7 @@
 CKAN_FORK=ckan
 
 if [[ ! -z $1 && $1 == '2.8' ]]; then
-    CKAN_VERSION=2.8.3
+    CKAN_VERSION=2.8.3-dgu
     CKAN_FORK=alphagov
     SRC_DIR=2.8
 elif [[ ! -z $1 && $1 == '2.9' ]]; then

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -5,6 +5,7 @@ CKAN_FORK=ckan
 
 if [[ ! -z $1 && $1 == '2.8' ]]; then
     CKAN_VERSION=2.8.3
+    CKAN_FORK=alphagov
     SRC_DIR=2.8
 elif [[ ! -z $1 && $1 == '2.9' ]]; then
     CKAN_VERSION=2.9-dgu


### PR DESCRIPTION
### What

This PR:

1. Specifies the `CKAN_FORK` variable in `bootstrap.sh` as alphagov over the default ckan for ckan 2.8, thus changing the ckan we're using from a clone of the project itself to our own fork when working on 2.8 locally.
2. Changes the `CKAN_VERSION` to `2.8.3-dgu`, meaning that the ckan branch that gets pulled from our ckan fork will be `ckan-2.8.3-dgu`, [our branch for the 2.8 upgrade work](https://github.com/alphagov/ckan/tree/ckan-2.8.3-dgu).

### Why

This was a decision made following a discussion within the team around how to handle this card <https://trello.com/c/JcV3NY27/137-fix-organogram-upload-fields>. The work required is a small change to one js file (`basic-form.js`) in the ckan project itself. This was [already merged into ckan master](https://github.com/ckan/ckan/pull/5278) but we need this change to be in ckan 2.8. The decision was made that re-pointing to our own fork and applying the necessary fix to that fork was the simplest option as we'll only need to work off of this fork for the duration of the 2.8 upgrade, at which point we can swap back to the main ckan repo (a setup already being used when working with ckan 2.9).