### PR TITLE
development requirement installation: add whitelist mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,3 +311,4 @@ ckan
 ## Known Issues
 
 * The SOLR index does not contain harvest metadata which is required by the CSW load job. A work around has been to run a solr reindex cronjob every 5 minutes to ensure that it picks up the latest when a harvest job is run. On production there is a similar cron job running but it only runs once a day.
+* The `-dev` dependencies of all discovered extensions are installed into the python environment at startup time by default, but this can lead to conflicts. If this leads to trouble getting test suites to pass, the variable `DEV_EXTENSIONS_WHITELIST` can be set to a comma-separated list of extensions (by directory name under `$SRC_EXTENSIONS_DIR`) for which dev dependencies should be installed.

--- a/ckan-dev/setup/start_ckan_development.sh
+++ b/ckan-dev/setup/start_ckan_development.sh
@@ -6,7 +6,9 @@ echo "Extension dir contents:"
 ls -la $SRC_EXTENSIONS_DIR
 for i in $SRC_EXTENSIONS_DIR/*
 do
-    if [ -d $i ];
+    if [ -d $i ] && (
+        [ -z "$DEV_EXTENSIONS_WHITELIST" ] || [[ ",$DEV_EXTENSIONS_WHITELIST," =~ ",$(basename $i)," ]]
+    );
     then
 
         if [ -f $i/pip-requirements.txt ];


### PR DESCRIPTION
Related to https://trello.com/c/GvIQrpVq 

Extensions' dev requirements frequently conflict with each other. Attempting to install them all one after the other in the same env is a recipe for strangeness. Add `$DEV_EXTENSIONS_WHITELIST`, a comma-separated list of repo names to install dev dependencies for at startup. Ignored if not set.