### PR TITLE
Add dgu publish

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,12 @@ DEV_CKAN_SQLALCHEMY_URL=postgresql://ckan:ckan@db/ckan
 CKAN_DATASTORE_WRITE_URL=postgresql://ckan:ckan@db/datastore
 CKAN_DATASTORE_READ_URL=postgresql://datastore_ro:datastore@db/datastore
 
+# DGU Publish
+DATABASE_URL=postgresql://ckan:ckan@db/publish_data_beta_development
+ES_HOST=http://elasticsearch:9200
+RAILS_ENV=development
+REDIS_HOST=redis 
+
 # Test database connections
 TEST_CKAN_SQLALCHEMY_URL=postgres://ckan:ckan@db/ckan_test
 TEST_CKAN_DATASTORE_WRITE_URL=postgresql://ckan:ckan@db/datastore_test
@@ -23,7 +29,7 @@ TEST_CKAN_DATASTORE_READ_URL=postgresql://datastore_ro:datastore@db/datastore_te
 
 # Other services connections
 CKAN_SOLR_URL=http://solr:8983/solr/ckan
-CKAN_REDIS_URL=redis://redis:6379/1
+DEV_CKAN_REDIS_URL=redis://redis:6379/1
 CKAN_DATAPUSHER_URL=http://datapusher:8800
 CKAN__DATAPUSHER__CALLBACK_URL_BASE=http://ckan:5000
 

--- a/README.md
+++ b/README.md
@@ -55,19 +55,20 @@ To start the containers:
 
 ## Development mode
 
-To develop local extensions use the `docker-compose.dev.yml` file:
-
 To setup your dev environment by cloning ckan and the extensions to your local src directory:
 
-    ./scripts/bootstrap.sh <version> # eg ./scripts/bootstrap.sh 2.8  If no version is supplied the default of 2.7 is used
+    ./scripts/bootstrap.sh <version> <?full>  # eg ./scripts/bootstrap.sh 2.8  If no version is supplied the default of 2.7 is used, the optional full flag can be used to also build the stack with DGU publish (https://github.com/alphagov/datagovuk_publish)
 
 To build the images:
 
-    ./scripts/rebuild-ckan.sh <version> <optional all>#  eg ./scripts/bootstrap.sh 2.8  If no version is supplied the default of 2.7 is used. If starting from new, the script will take at least 20 minutes to run. If `all` is passed as an argument all the docker project will be rebuilt, otherwise the docker image from dockerhub for ckan-main will be pulled and only postdev will be built.
+    ./scripts/rebuild-ckan.sh <version> <?(main, all)> <?full>  #  eg ./scripts/bootstrap.sh 2.8  
+    - If no version is supplied the default of 2.7 is used. If starting from new, the script will take at least 20 minutes to run. 
+    - If `all` is passed as a second argument all the docker project will be rebuilt. If `main` is passed in the ckan-main and ckan-postdev projects will be built. Otherwise the docker image from dockerhub for ckan-main will be pulled and only postdev will be built.
+    - if `full` is passed in as an argument Publish (https://github.com/alphagov/datagovuk_publish) will also be built as part of the stack.
 
 To start the containers:
 
-	./scripts/start-ckan.sh <version>  eg ./scripts/bootstrap.sh 2.8  If no version is supplied the default of 2.7 is used
+	./scripts/start-ckan.sh <version> <?full> eg ./scripts/bootstrap.sh 2.8  If no version is supplied the default of 2.7 is used. If full is supplied as the second argument DGU Publish (https://github.com/alphagov/datagovuk_publish) will also be started on the stack.
 
 See [CKAN Images](#ckan-images) for more details of what happens when using development mode.
 
@@ -91,7 +92,7 @@ for help
 
 to pass in args
 
-    ./scripts/reset-ckan.sh <image (postdev, main, dev, base)> <reset volumes (Yn)> <version (default 2.7, 2.8)>
+    ./scripts/reset-ckan.sh <image (postdev, main, dev, base)> <reset volumes (Yn)> <version (default 2.7, 2.8, 2.9)> <?full to remove publish images and elasticsearch volume>
 
 ### Updating CKAN configuration, production.ini
 

--- a/docker-compose-2.7-full.yml
+++ b/docker-compose-2.7-full.yml
@@ -1,0 +1,49 @@
+version: "3"
+
+services:
+  elasticsearch:
+    container_name: elasticsearch
+    image: docker.elastic.co/elasticsearch/elasticsearch:6.8.9
+    environment:
+      - node.name=elasticsearch
+      - "ES_JAVA_OPTS=-Xms1g -Xmx1g"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    volumes:
+      - es_data:/usr/share/elasticsearch/data
+    ports:
+      - 9200:9200
+    networks:
+      - ckan-2.7
+
+  publish:
+    image: govuk/publish:2.7
+    container_name: publish
+    build:
+      context: ./src/2.7/datagovuk_publish/
+    env_file:
+      - .env-2.7
+    links:
+      - db
+      - elasticsearch
+      - redis
+      - ckan-postdev
+    depends_on: 
+      - db
+      - elasticsearch
+      - redis  
+    command: bash -c "./bin/setup-docker.sh"
+    volumes:
+      - ./src/2.7/datagovuk_publish:/srv/app/datagovuk_publish
+      - ./logs/2.7:/var/log/sidekiq
+    networks:
+      - ckan-2.7
+
+volumes:
+  es_data:
+
+networks:
+    ckan-2.7:
+        driver: bridge

--- a/docker-compose-2.8-full.yml
+++ b/docker-compose-2.8-full.yml
@@ -1,0 +1,49 @@
+version: "3"
+
+services:
+  elasticsearch-2.8:
+    container_name: elasticsearch-2.8
+    image: docker.elastic.co/elasticsearch/elasticsearch:6.8.9
+    environment:
+      - node.name=elasticsearch
+      - "ES_JAVA_OPTS=-Xms1g -Xmx1g"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    volumes:
+      - es_data-2.8:/usr/share/elasticsearch/data
+    ports:
+      - 9201:9200
+    networks:
+      - ckan-2.8
+
+  publish-2.8:
+    image: govuk/publish:2.8
+    container_name: publish-2.8
+    build:
+      context: ./src/2.8/datagovuk_publish/
+    env_file:
+      - .env-2.8
+    links:
+      - db-2.8:db
+      - elasticsearch-2.8:elasticsearch
+      - redis-2.8:redis
+      - ckan-postdev-2.8:ckan-postdev
+    depends_on: 
+      - db-2.8
+      - elasticsearch-2.8
+      - redis-2.8
+    command: bash -c "./bin/setup-docker.sh"
+    volumes:
+      - ./src/2.8/datagovuk_publish:/srv/app/datagovuk_publish
+      - ./logs/2.8:/var/log/sidekiq
+    networks:
+      - ckan-2.8
+
+volumes:
+  es_data-2.8:
+
+networks:
+    ckan-2.8:
+        driver: bridge

--- a/docker-compose-2.9-full.yml
+++ b/docker-compose-2.9-full.yml
@@ -1,0 +1,49 @@
+version: "3"
+
+services:
+  elasticsearch-2.9:
+    container_name: elasticsearch-2.9
+    image: docker.elastic.co/elasticsearch/elasticsearch:6.8.9
+    environment:
+      - node.name=elasticsearch
+      - "ES_JAVA_OPTS=-Xms1g -Xmx1g"
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    volumes:
+      - es_data-2.9:/usr/share/elasticsearch/data
+    ports:
+      - 9202:9200
+    networks:
+      - ckan-2.9
+
+  publish-2.9:
+    image: govuk/publish:2.9
+    container_name: publish-2.9
+    build:
+      context: ./src/2.9/datagovuk_publish/
+    env_file:
+      - .env-2.9
+    links:
+      - db-2.9:db
+      - elasticsearch-2.9:elasticsearch
+      - redis-2.9:redis
+      - ckan-postdev-2.9:ckan-postdev
+    depends_on: 
+      - db-2.9
+      - elasticsearch-2.9
+      - redis-2.9
+    command: bash -c "./bin/setup-docker.sh"
+    volumes:
+      - ./src/2.9/datagovuk_publish:/srv/app/datagovuk_publish
+      - ./logs/2.9:/var/log/sidekiq
+    networks:
+      - ckan-2.9
+
+volumes:
+  es_data-2.9:
+
+networks:
+    ckan-2.9:
+        driver: bridge

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -29,4 +29,8 @@ git clone https://github.com/geopython/pycsw.git --branch 2.4.0
 git clone https://github.com/alphagov/ckan-mock-harvest-sources.git
 # appending this should quietly override any prior settings of the variable
 echo $'\nmap $host $mock_absolute_root_url { default "http://static-mock-harvest-source:11088/"; }' >> ckan-mock-harvest-sources/static/vars.conf
+
+if [[ ! -z $2 && $2 == 'full' ]]; then
+    git clone https://github.com/alphagov/datagovuk_publish.git
+fi
 popd

--- a/scripts/rebuild-ckan.sh
+++ b/scripts/rebuild-ckan.sh
@@ -22,6 +22,13 @@ else
     BUILD=postdev
 fi
 
+if [[ ! -z $3 && $3 == 'full' ]]; then
+    echo "=== Full DGU stack"
+    FULL_ARGS="-f docker-compose-$VERSION-full.yml"
+else
+    echo "=== CKAN stack"
+fi
+
 if [[ $BUILD == 'all' || $BUILD == 'main' ]]; then
 
     if [[ $BUILD == 'all' ]]; then
@@ -34,4 +41,4 @@ fi
 
 (cd ckan-postdev && docker build -t govuk/ckan-postdev:$VERSION -f $VERSION/Dockerfile .)
 
-docker-compose -f docker-compose-$VERSION.yml build
+docker-compose -f docker-compose-$VERSION.yml $FULL_ARGS build

--- a/scripts/reset-volumes.sh
+++ b/scripts/reset-volumes.sh
@@ -6,6 +6,10 @@ elif [[ ! -z $1 && $1 == '2.9' ]]; then
     VERSION=-2.9
 fi
 
+if [[ ! -z $2 && $2 == 'full' ]]; then
+    docker volume rm docker-ckan_es_data$VERSION
+fi
+
 docker volume rm docker-ckan_ckan_storage$VERSION
 docker volume rm docker-ckan_solr_data$VERSION
 docker volume rm docker-ckan_pg_data$VERSION

--- a/scripts/start-ckan.sh
+++ b/scripts/start-ckan.sh
@@ -7,4 +7,11 @@ else
     VERSION=2.7
 fi
 
-docker-compose -f docker-compose-$VERSION.yml up
+if [[ ! -z $2 && $2 == 'full' ]]; then
+    echo "=== Full DGU stack"
+    FULL_ARGS="-f docker-compose-$VERSION-full.yml"
+else
+    echo "=== CKAN stack"
+fi
+
+docker-compose -f docker-compose-$VERSION.yml $FULL_ARGS up


### PR DESCRIPTION
## What

Add datagovuk publish app and elasticsearch service to this docker stack, this will enable devs to see how publish integrates with the CKAN stack. 

By default when building, starting or reseting the stack it won't bring up the additional publish and elasticsearch services, only by appending `full` to the scripts will elasticsearch and publish also be built, started or reseted.

When first run, until a publisher / organisation is created the sidekiq job will error as it expects at least 1 to exist. Logs from sidekiq are available in the logs area.

## Reference

https://trello.com/c/7w63sDE3/139-add-dgu-publish-to-docker-ckan