### PR TITLE
Add branch to ckanext-datagovuk for 2.8

### DIFF
--- a/ckan-main/2.8/Dockerfile.dev
+++ b/ckan-main/2.8/Dockerfile.dev
@@ -12,7 +12,7 @@ RUN echo UTC > /etc/timezone
 ENV DCAT_SHA=8c55890e7bf9644460ae71470f37abbd9295c9fa
 ENV HARVEST_SHA=73db5f1ee67fc86521cfd1861b5d699ff45b1e33
 ENV SPATIAL_SHA=c35e1249cfb3c7b2f1286f433fd51c6fe8f05b72
-ENV DATAGOVUK_VERSION=release_165
+ENV DATAGOVUK_VERSION=master-2.8
 
 RUN which python && \
     pip install --upgrade setuptools && \

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -2,11 +2,13 @@
 
 # Default git fork
 CKAN_FORK=ckan
+DATAGOVUK_BRANCH=master
 
 if [[ ! -z $1 && $1 == '2.8' ]]; then
     CKAN_VERSION=2.8.3-dgu
     CKAN_FORK=alphagov
     SRC_DIR=2.8
+    DATAGOVUK_BRANCH=master-2.8
 elif [[ ! -z $1 && $1 == '2.9' ]]; then
     CKAN_VERSION=2.9-dgu
     CKAN_FORK=alphagov
@@ -20,7 +22,7 @@ mkdir -p src/$SRC_DIR
 pushd src/$SRC_DIR
 git clone --branch ckan-$CKAN_VERSION https://github.com/$CKAN_FORK/ckan
 
-git clone https://github.com/alphagov/ckanext-datagovuk
+git clone --branch $DATAGOVUK_BRANCH https://github.com/alphagov/ckanext-datagovuk
 git clone https://github.com/alphagov/ckanext-harvest
 git clone --branch dgu-fixes https://github.com/alphagov/ckanext-spatial
 git clone https://github.com/ckan/ckanext-dcat

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -18,6 +18,8 @@ else
     SRC_DIR=2.7
 fi
 
+echo -e "Please ensure that the ${SRC_DIR} src directory is empty before running this command. This command will not populate the directories required for this project to run effectively unless said directories are already empty or don't exist.\n"
+
 mkdir -p src/$SRC_DIR
 pushd src/$SRC_DIR
 git clone --branch ckan-$CKAN_VERSION https://github.com/$CKAN_FORK/ckan


### PR DESCRIPTION
### What

Adds a branch param to the 2.8 bootstrap of ckanext-datagovuk. The variable `DATAGOVUK_BRANCH` is set at the top of the bootstrap script, set explicitly in the 2.8 if block and applied to the `git clone` via the `--branch` param.

### Why

We're currently using a branch off of master for ckanext-datagovuk called `master-2.8` for all ckan 2.8 work to prevent non-production ready code going into master (production is currently on ckan 2.7 which could be disrupted by the styling changes we're making). This ensures that docker-ckan references that branch when setting up the ckan project via docker-ckan.