### PR TITLE
Add dynamic mock harvest source

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,8 @@ ckan
 
 ## Mock harvest source
 
+### Static
+
 The docker compose configurations start an instance of the static [mock harvest source](https://github.com/alphagov/ckan-mock-harvest-sources)
 which should make it easy to populate the database with some basic standard content. To use this, add a harvest
 source with the address `http://static-mock-harvest-source:11088` and of type "CKAN". The content served by this
@@ -330,6 +332,14 @@ For this harvest source to appear to work _completely_ right, you may need to ad
 CKAN's web interface will link "directly" to the actual data files (and of course, it will be doing so using the
 hostname _it_ knows it by), so you have to do some tweaking of your host machine's configuration to allow your
 browser to resolve that address correctly.
+
+### Dynamic
+
+The docker compose configurations also start an instance of the dynamic [mock harvest source](https://github.com/alphagov/ckan-mock-harvest-sources)
+which can be used to test out harvesting. To use this, add a harvest
+source with the address `http://dynamic-mock-harvest-source:8001/1/` and of type "WAF". 
+
+Further documentation about the dynamic mock harvest source can be [read](https://github.com/alphagov/ckan-mock-harvest-sources/tree/master/dynamic) which which will enable you to define the number of datasets available for harvesting and the delay on the harvest source server.
 
 ## Known Issues
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Find out names of running containers:
 
 To ssh onto the ckan container:
 
-    docker exec -it docker-ckan_ckan-postdev_1 bash
+    docker exec -it ckan-2.7 bash
 
 To ssh onto the postgres container:
 

--- a/docker-compose-2.7.yml
+++ b/docker-compose-2.7.yml
@@ -2,6 +2,7 @@ version: "3"
 
 services:
   ckan-postdev:
+    container_name: ckan-2.7
     image: govuk/ckan-postdev:2.7
     build:
       context: ckan-postdev/
@@ -87,6 +88,18 @@ services:
     networks:
       - ckan-2.7
 
+  dynamic-mock-harvest-source:
+    image: govuk/dynamic-mock-harvest-source:2.7
+    container_name: dynamic-mock-harvest-source
+    build:
+      context: ./src/2.7/ckan-mock-harvest-sources/dynamic/
+    ports:
+      - "8001:8001"
+    networks:
+      - ckan-2.7
+    volumes:
+      - ./src/2.7/ckan-mock-harvest-sources/dynamic:/srv/apps/dynamic-mock-harvest-source
+  
 volumes:
   ckan_storage:
   pg_data:

--- a/docker-compose-2.8.yml
+++ b/docker-compose-2.8.yml
@@ -2,6 +2,7 @@ version: "3"
 
 services:
   ckan-postdev-2.8:
+    container_name: ckan-2.8
     image: govuk/ckan-postdev:2.8
     build:
       context: ckan-postdev/

--- a/docker-compose-2.9.yml
+++ b/docker-compose-2.9.yml
@@ -2,6 +2,7 @@ version: "3"
 
 services:
   ckan-postdev-2.9:
+    container_name: ckan-2.9
     image: govuk/ckan-postdev:2.9
     build:
       context: ckan-postdev/


### PR DESCRIPTION
## What

Adds in a dynamic mock harvest source so that we can easily test different harvest scenarios.

Also set container name for ckan to be more readable, so can now connect with `docker exec -it ckan-2.7 bash` rather than `docker exec -it docker-ckan_ckan-postdev_1 bash`.