### PR TITLE
Fix docker stack

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,7 +32,7 @@ TEST_CKAN_DATASTORE_WRITE_URL=postgresql://ckan:ckan@db/datastore_test
 TEST_CKAN_DATASTORE_READ_URL=postgresql://datastore_ro:datastore@db/datastore_test
 
 # Other services connections
-CKAN_SOLR_URL=http://solr:8983/solr/ckan
+DEV_CKAN_SOLR_URL=http://solr:8983/solr/ckan
 DEV_CKAN_REDIS_URL=redis://redis:6379/1
 CKAN_DATAPUSHER_URL=http://datapusher:8800
 CKAN__DATAPUSHER__CALLBACK_URL_BASE=http://ckan:5000

--- a/README.md
+++ b/README.md
@@ -112,7 +112,8 @@ to pass in args
 
 ### Updating CKAN configuration, production.ini
 
-When you have to make changes to the CKAN config file, `production.ini`, update the `production.ini` file located in `ckan-main/setup` project to get a faster turn around time. Changing it on `ckan-base/setup` will increase the turn around time to more than 10 minutes rather than under 5 minutes within the `ckan-main` project. `production.ini` has been left in `ckan-base` because the Dockerfile in `ckan-base` has references to it.
+When you have to make changes to the CKAN config file, `production.ini`, update the `production.ini` file located in `ckan-main/setup` project to get a faster turn around time. Changing it on `ckan-base/setup` will increase the turn around time to more than 10 minutes rather than under 5 minutes within the `ckan-main` project. `production.ini` has been left in `ckan-base` because the Dockerfile in `ckan-base` has references to it. You will also need to run `./scripts/rebuild-ckan.sh main` in order to rebuild the image from your local changes rather than
+use the image in docker hub.
 
 ### Useful tips during development
 
@@ -161,6 +162,15 @@ You can initialise the CKAN config by running this command -
     /srv/app/init_config.sh
 
 For extensions run the relevant `setup` file found in `/docker-entrypoint.d`, e.g. if you changed the harvest branch run `/docker-entrypoint.d/setup_harvest.sh`
+
+#### Container doesn't have additional files or updates to files
+
+It's possible that one of the images failed to build so docker is using a cached version of the image to build the container. 
+To fix the docker image it may be necessary to build the stack without using cached images:
+
+    ../scripts/rebuild-ckan.sh dev no-cache
+
+Will rebuild the stack from the `ckan-dev` Dockerfile.
 
 ## Testing
 

--- a/ckan-base/setup/prerun.py
+++ b/ckan-base/setup/prerun.py
@@ -66,7 +66,7 @@ def check_solr_connection(retry=None):
         print '[prerun] Giving up after 5 tries...'
         sys.exit(1)
 
-    url = os.environ.get('CKAN_SOLR_URL', '')
+    url = os.environ.get('DEV_CKAN_SOLR_URL', '')
     search_url = '{url}/select/?q=*&wt=json'.format(url=url)
 
     try:

--- a/ckan-base/setup/production.ini
+++ b/ckan-base/setup/production.ini
@@ -101,9 +101,11 @@ ckan.harvest.mq.type = redis
 ckan.harvest.mq.hostname = redis
 ckan.harvest.mq.port = 6379
 ckan.harvest.mq.redis_db = 1
+ckan.harvest.timeout = 10
 
 ckan.spatial.validator.profiles = iso19139eden,constraints-1.4,gemini2-1.3
 ckan.spatial.validator.reject = true
+ckan.spatial.use_default_tag_schema = true
 
 # Define which views should be created by default
 # (plugins must be loaded in ckan.plugins)

--- a/ckan-dev/setup/init_config.sh
+++ b/ckan-dev/setup/init_config.sh
@@ -1,15 +1,18 @@
-# Update the plugins setting in the ini file with the values defined in the env var
-echo "Loading the following plugins: $CKAN__PLUGINS"
+# update the production.ini with env vars
 paster --plugin=ckan config-tool $CKAN_INI \
     "sqlalchemy.url = $DEV_CKAN_SQLALCHEMY_URL" \
     "ckan.site_url = $DEV_CKAN_SITE_URL" \
     "solr_url = $DEV_CKAN_SOLR_URL" \
     "ckan.redis.url = $DEV_CKAN_REDIS_URL" \
     "ckan.site_url = $DEV_CKAN_SITE_URL" \
-    "ckan.plugins = $CKAN__PLUGINS"
+    "ckan.plugins = $CKAN__PLUGINS" \
+    "ckan.datagovuk.s3_aws_access_key_id = $CKAN_S3_AWS_ACCESS_KEY_ID" \
+    "ckan.datagovuk.s3_aws_secret_access_key = $CKAN_S3_AWS_SECRET_ACCESS_KEY" \
+    "ckan.datagovuk.s3_bucket_name = $CKAN_S3_BUCKET_NAME" \
+    "ckan.datagovuk.s3_url_prefix = $CKAN_S3_URL_PREFIX" \
+    "ckan.datagovuk.s3_aws_region_name = $CKAN_S3_AWS_REGION_NAME"
 
 # Update test-core.ini DB, SOLR & Redis settings
-echo "Loading test settings into test-core.ini"
 paster --plugin=ckan config-tool $SRC_DIR/ckan/test-core.ini \
     "sqlalchemy.url = $TEST_CKAN_SQLALCHEMY_URL" \
     "ckan.datstore.write_url = $TEST_CKAN_DATASTORE_WRITE_URL" \
@@ -18,9 +21,21 @@ paster --plugin=ckan config-tool $SRC_DIR/ckan/test-core.ini \
     "solr_url = $TEST_CKAN_SOLR_URL" \
     "ckan.redis.url = $TEST_CKAN_REDIS_URL"
 
-paster --plugin=ckan config-tool $APP_DIR/production.ini \
-  "ckan.datagovuk.s3_aws_access_key_id = $CKAN_S3_AWS_ACCESS_KEY_ID" \
-  "ckan.datagovuk.s3_aws_secret_access_key = $CKAN_S3_AWS_SECRET_ACCESS_KEY" \
-  "ckan.datagovuk.s3_bucket_name = $CKAN_S3_BUCKET_NAME" \
-  "ckan.datagovuk.s3_url_prefix = $CKAN_S3_URL_PREFIX" \
-  "ckan.datagovuk.s3_aws_region_name = $CKAN_S3_AWS_REGION_NAME"
+# update test.ini in ckan and extensions
+for i in $SRC_EXTENSIONS_DIR/*
+do
+    if [ -d $i ] && (
+        [ -z "$DEV_EXTENSIONS_WHITELIST" ] || [[ ",$DEV_EXTENSIONS_WHITELIST," =~ ",$(basename $i)," ]]
+    );
+    then
+        if [ -f $i/test.ini ]; then
+            echo "=== Updating test config in $i"
+            paster --plugin=ckan config-tool $i/test.ini \
+                "use = config:../../src/ckan/test-core.ini" \
+                "sqlalchemy.url = $TEST_CKAN_SQLALCHEMY_URL" \
+                "ckan.site_url = $TEST_CKAN_SITE_URL" \
+                "solr_url = $TEST_CKAN_SOLR_URL" \
+                "ckan.redis.url = $TEST_CKAN_REDIS_URL"
+        fi
+    fi
+done

--- a/ckan-main/2.7/Dockerfile.dev
+++ b/ckan-main/2.7/Dockerfile.dev
@@ -1,6 +1,6 @@
 FROM govuk/ckan-dev:2.7
 
-MAINTAINER Your Name Here <you@example.com>
+MAINTAINER Data Gov UK <team@data.gov.uk>
 
 # Set timezone
 RUN cp /usr/share/zoneinfo/UTC /etc/localtime
@@ -11,8 +11,8 @@ RUN echo UTC > /etc/timezone
 
 ENV DCAT_SHA=b693bc911578cfc28e80c871d8e8eddb07411cfc
 ENV HARVEST_SHA=944f67c48d274df79a2719b5553698e3e6980a51
-ENV SPATIAL_SHA=c35e1249cfb3c7b2f1286f433fd51c6fe8f05b72
-ENV DATAGOVUK_VERSION=release_165
+ENV SPATIAL_SHA=f8bfb7501aaee49dd5a2419ba8785104c2f0d0a9
+ENV DATAGOVUK_VERSION=release_202
 
 RUN which python && \
     pip install --upgrade setuptools && \
@@ -51,9 +51,7 @@ COPY setup/pycsw_supervisord.conf /etc/supervisord.d/pycsw_supervisord.conf
 
 ENV PYCSW_CONFIG=$APP_DIR/pycsw.cfg 
 
-WORKDIR $SRC_EXTENSIONS_DIR
-
-RUN git clone --branch 2.4.0 https://github.com/geopython/pycsw.git && \
+RUN cd $SRC_EXTENSIONS_DIR && git clone --branch 2.4.0 https://github.com/geopython/pycsw.git && \
     cd pycsw && \
     pip install -e . && \
     python setup.py build && \

--- a/ckan-main/2.8/Dockerfile.dev
+++ b/ckan-main/2.8/Dockerfile.dev
@@ -1,6 +1,6 @@
 FROM govuk/ckan-dev:2.8
 
-MAINTAINER Your Name Here <you@example.com>
+MAINTAINER Data Gov UK <team@data.gov.uk>
 
 # Set timezone
 RUN cp /usr/share/zoneinfo/UTC /etc/localtime
@@ -11,7 +11,7 @@ RUN echo UTC > /etc/timezone
 
 ENV DCAT_SHA=b693bc911578cfc28e80c871d8e8eddb07411cfc
 ENV HARVEST_SHA=944f67c48d274df79a2719b5553698e3e6980a51
-ENV SPATIAL_SHA=c35e1249cfb3c7b2f1286f433fd51c6fe8f05b72
+ENV SPATIAL_SHA=f8bfb7501aaee49dd5a2419ba8785104c2f0d0a9
 ENV DATAGOVUK_VERSION=master-2.8
 
 RUN which python && \
@@ -51,9 +51,7 @@ COPY setup/pycsw_supervisord.conf /etc/supervisord.d/pycsw_supervisord.conf
 
 ENV PYCSW_CONFIG=$APP_DIR/pycsw.cfg 
 
-WORKDIR $SRC_EXTENSIONS_DIR
-
-RUN git clone  --branch 2.4.0 https://github.com/geopython/pycsw.git && \
+RUN cd $SRC_EXTENSIONS_DIR && git clone --branch 2.4.0 https://github.com/geopython/pycsw.git && \
     cd pycsw && \
     pip install -e . && \
     python setup.py build && \

--- a/ckan-main/2.9/Dockerfile.dev
+++ b/ckan-main/2.9/Dockerfile.dev
@@ -11,7 +11,7 @@ RUN echo UTC > /etc/timezone
 
 ENV DCAT_SHA=b693bc911578cfc28e80c871d8e8eddb07411cfc
 ENV HARVEST_SHA=944f67c48d274df79a2719b5553698e3e6980a51
-ENV SPATIAL_SHA=c35e1249cfb3c7b2f1286f433fd51c6fe8f05b72
+ENV SPATIAL_SHA=f8bfb7501aaee49dd5a2419ba8785104c2f0d0a9
 ENV DATAGOVUK_VERSION=ckan-2.9
 
 RUN which python && \
@@ -51,9 +51,7 @@ COPY setup/pycsw_supervisord.conf /etc/supervisord.d/pycsw_supervisord.conf
 
 ENV PYCSW_CONFIG=$APP_DIR/pycsw.cfg 
 
-WORKDIR $SRC_EXTENSIONS_DIR
-
-RUN git clone  --branch 2.4.0 https://github.com/geopython/pycsw.git && \
+RUN cd $SRC_EXTENSIONS_DIR && git clone --branch 2.4.0 https://github.com/geopython/pycsw.git && \
     cd pycsw && \
     pip install -e . && \
     python setup.py build && \

--- a/ckan-main/setup/production.ini
+++ b/ckan-main/setup/production.ini
@@ -101,9 +101,11 @@ ckan.harvest.mq.type = redis
 ckan.harvest.mq.hostname = redis
 ckan.harvest.mq.port = 6379
 ckan.harvest.mq.redis_db = 1
+ckan.harvest.timeout = 10
 
 ckan.spatial.validator.profiles = iso19139eden,constraints-1.4,gemini2-1.3
 ckan.spatial.validator.reject = true
+ckan.spatial.use_default_tags_schema = true
 
 # Define which views should be created by default
 # (plugins must be loaded in ckan.plugins)

--- a/docker-compose-2.8.yml
+++ b/docker-compose-2.8.yml
@@ -78,6 +78,18 @@ services:
     networks:
       - ckan-2.8
 
+  dynamic-mock-harvest-source-2.8:
+    image: govuk/dynamic-mock-harvest-source:2.8
+    container_name: dynamic-mock-harvest-source-2.8
+    build:
+      context: ./src/2.8/ckan-mock-harvest-sources/dynamic/
+    ports:
+      - "8002:8001"
+    networks:
+      - ckan-2.8
+    volumes:
+      - ./src/2.8/ckan-mock-harvest-sources/dynamic:/srv/apps/dynamic-mock-harvest-source
+
   static-mock-harvest-source-2.8:
     container_name: static-mock-harvest-source-2.8
     build:

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -26,7 +26,7 @@ git clone --branch ckan-$CKAN_VERSION https://github.com/$CKAN_FORK/ckan
 
 git clone --branch $DATAGOVUK_BRANCH https://github.com/alphagov/ckanext-datagovuk
 git clone https://github.com/ckan/ckanext-harvest
-git clone --branch dgu-fixes https://github.com/alphagov/ckanext-spatial
+git clone https://github.com/alphagov/ckanext-spatial
 git clone https://github.com/ckan/ckanext-dcat
 git clone https://github.com/geopython/pycsw.git --branch 2.4.0 
 

--- a/scripts/rebuild-ckan.sh
+++ b/scripts/rebuild-ckan.sh
@@ -20,6 +20,9 @@ if [[ ! -z $2 && $2 == 'full' ]]; then
 elif [[ ! -z $2 && $2 == 'all' ]]; then
     echo "=== Building all CKAN projects"
     BUILD=all
+elif [[ ! -z $2 && $2 == 'dev' ]]; then
+    echo "=== Building dev, main and postdev"
+    BUILD=dev
 elif [[ ! -z $2 && $2 == 'main' ]]; then
     echo "=== Building main and postdev"
     BUILD=main
@@ -33,15 +36,24 @@ if [[ ! -z $3 && $3 == 'full' ]]; then
     FULL_ARGS="-f docker-compose-$VERSION-full.yml"
 elif [[ ! -z $2 && $2 != 'full' ]]; then
     echo "=== CKAN stack"
+    NO_CACHE=''
+    if [[ ! -z $3 && $3 == 'no-cache' ]]; then
+        echo "=== no cache"
+        NO_CACHE="--no-cache"
+    fi
 fi
 
-if [[ $BUILD == 'all' || $BUILD == 'main' ]]; then
+if [[ $BUILD == 'all' || $BUILD == 'main' || $BUILD == 'dev' ]]; then
 
     if [[ $BUILD == 'all' ]]; then
-        (cd ckan-base && docker build -t govuk/ckan-base:$VERSION -f $VERSION/Dockerfile .)
-        (cd ckan-dev && docker build -t govuk/ckan-dev:$VERSION -f $VERSION/Dockerfile .)
+        (cd ckan-base && docker build $NO_CACHE -t govuk/ckan-base:$VERSION -f $VERSION/Dockerfile .)
     fi
-    (cd ckan-main && docker build -t govuk/ckan-main:$VERSION -f $VERSION/Dockerfile.dev .)
+
+    if [[ $BUILD == 'all' || $BUILD == 'dev' ]]; then
+        (cd ckan-dev && docker build $NO_CACHE -t govuk/ckan-dev:$VERSION -f $VERSION/Dockerfile .)
+    fi
+
+    (cd ckan-main && docker build $NO_CACHE -t govuk/ckan-main:$VERSION -f $VERSION/Dockerfile.dev .)
 
 fi
 


### PR DESCRIPTION
## What

The Dockerfile in the ckan-main folder referenced a spatial commit which caused the build to break. This meant that any changes to this Dockerfile and other Dockerfiles using it would not be built so the `./scripts/rebuild-ckan.sh` command would use a cached image. This would make it difficult to see any changes that have been added to the Dockerfiles. 

A `no-cache` option has also been added to the `rebuild-ckan.sh` script to ensure that cached images are not used, this will make the rebuild take much longer but would ensure that the images being built are correct, so should only be used if you expect a change in a file or don't have an expected file in the container.

Additionally to help with switching of branches the `init_config.sh` has been updated to also update ckan and extensions in the `src_extensions` directory on the container.

## Reference 

https://trello.com/c/MwnYyvKW/237-fix-docker-ckan-setup