### PR TITLE
Add test data

### DIFF
--- a/ckan-base/2.8/Dockerfile
+++ b/ckan-base/2.8/Dockerfile
@@ -8,9 +8,9 @@ ENV CKAN_INI=${APP_DIR}/production.ini
 ENV TEST_CKAN_INI=${SRC_DIR}/ckan/test-core.ini
 ENV PIP_SRC=${SRC_DIR}
 ENV CKAN_STORAGE_PATH=/var/lib/ckan
-ENV GIT_URL=https://github.com/ckan/ckan.git
+ENV GIT_URL=https://github.com/alphagov/ckan.git
 # CKAN version to build
-ENV GIT_BRANCH=ckan-2.8.3
+ENV GIT_BRANCH=ckan-2.8.3-dgu
 
 WORKDIR ${APP_DIR}
 

--- a/ckan-dev/2.8/Dockerfile
+++ b/ckan-dev/2.8/Dockerfile
@@ -10,7 +10,7 @@ ENV SRC_EXTENSIONS_DIR=/srv/app/src_extensions
 RUN apk add --no-cache libffi-dev
 
 # Install CKAN dev requirements
-RUN pip install --no-binary :all: -r https://raw.githubusercontent.com/ckan/ckan/${GIT_BRANCH}/dev-requirements.txt
+RUN pip install --no-binary :all: -r https://raw.githubusercontent.com/alphagov/ckan/${GIT_BRANCH}/dev-requirements.txt
 
 # cryptography 2.9 is broken with this error message
 # ImportError: Error relocating /usr/lib/python2.7/site-packages/cryptography/hazmat/bindings/_openssl.so: RSA_get0_crt_params: symbol not found

--- a/ckan-main/2.8/Dockerfile.dev
+++ b/ckan-main/2.8/Dockerfile.dev
@@ -9,10 +9,17 @@ RUN echo UTC > /etc/timezone
 # Install any extensions needed by your CKAN instance
 # (Make sure to add the plugins to CKAN__PLUGINS in the .env file)
 
-ENV DCAT_SHA=b693bc911578cfc28e80c871d8e8eddb07411cfc
-ENV HARVEST_SHA=944f67c48d274df79a2719b5553698e3e6980a51
-ENV SPATIAL_SHA=f8bfb7501aaee49dd5a2419ba8785104c2f0d0a9
-ENV DATAGOVUK_VERSION=master-2.8
+ENV DCAT_SHA=b757e5be643a17f08b1bb102348c370abee149d5
+ENV HARVEST_SHA=af8c18ef1acf4e80e5d65aca301cd6869cef82f9
+ENV SPATIAL_SHA=46b706549aaf13a4ef2451d6185d7a90a75aeb0f
+ENV DATAGOVUK_VERSION=master
+ENV CKAN_TEST_SYSADMIN_NAME=testsysadmin
+ENV CKAN_TEST_SYSADMIN_PASSWORD=test1test
+
+# CKAN files in this project to avoid having to rebuild ckan-base and ckan-dev projects
+RUN echo "Copying main setup files"
+COPY setup/production.ini $APP_DIR/production.ini
+COPY setup/prerun.py $APP_DIR/prerun.py
 
 RUN which python && \
     pip install --upgrade setuptools && \
@@ -58,6 +65,3 @@ RUN cd $SRC_EXTENSIONS_DIR && git clone --branch 2.4.0 https://github.com/geopyt
     python setup.py install && \
     chown ckan $APP_DIR/pycsw.cfg && \
     chmod 644 $APP_DIR/pycsw.cfg
-
-# CKAN configuration, modify production.ini in this project to avoid rebuilding ckan-base and ckan-dev projects
-COPY setup/production.ini $APP_DIR/production.ini

--- a/ckan-main/docker-entrypoint.d/setup_datagovuk.sh
+++ b/ckan-main/docker-entrypoint.d/setup_datagovuk.sh
@@ -5,3 +5,7 @@ echo "====== Set up Data.gov.uk ======"
 echo "Update datagovuk SQLAlchemy URL"
 paster --plugin=ckan config-tool $SRC_EXTENSIONS_DIR/ckanext-datagovuk/test.ini \
     "sqlalchemy.url = $TEST_CKAN_SQLALCHEMY_URL"
+
+echo "Setup test data"
+paster --plugin=ckanext-datagovuk remove_dgu_test_data -c $CKAN_INI
+paster --plugin=ckanext-datagovuk create_dgu_test_data -c $CKAN_INI

--- a/ckan-main/setup/prerun.py
+++ b/ckan-main/setup/prerun.py
@@ -1,0 +1,198 @@
+import os
+import sys
+import subprocess
+import psycopg2
+import urllib2
+import time
+import re
+
+ckan_ini = os.environ.get('CKAN_INI', '/srv/app/production.ini')
+test_ckan_ini = os.environ.get('TEST_CKAN_INI', '/srv/app/src/test-core.ini')
+
+RETRY = 5
+
+def update_plugins():
+
+    plugins = os.environ.get('CKAN__PLUGINS', '')
+    print('[prerun] Setting the following plugins in {}:'.format(ckan_ini))
+    print(plugins)
+    cmd = ['paster', '--plugin=ckan', 'config-tool',
+           ckan_ini, 'ckan.plugins = {}'.format(plugins)]
+    subprocess.check_output(cmd, stderr=subprocess.STDOUT)
+    print '[prerun] Plugins set.'
+
+    
+def check_main_db_connection(retry=None):
+
+    conn_str = os.environ.get('DEV_CKAN_SQLALCHEMY_URL')
+    if not conn_str:
+        print '[prerun] DEV_CKAN_SQLALCHEMY_URL not defined, not checking db'
+    return check_db_connection(conn_str, retry)
+
+
+def check_datastore_db_connection(retry=None):
+
+    conn_str = os.environ.get('CKAN_DATASTORE_WRITE_URL')
+    if not conn_str:
+        print '[prerun] CKAN_DATASTORE_WRITE_URL not defined, not checking db'
+    return check_db_connection(conn_str, retry)
+
+
+def check_db_connection(conn_str, retry=None):
+
+    if retry is None:
+        retry = RETRY
+    elif retry == 0:
+        print '[prerun] Giving up after 5 tries...'
+        sys.exit(1)
+
+    try:
+        connection = psycopg2.connect(conn_str)
+
+    except psycopg2.Error as e:
+        print str(e)
+        print '[prerun] Unable to connect to the database, waiting...'
+        time.sleep(10)
+        check_db_connection(conn_str, retry=retry - 1)
+    else:
+        connection.close()
+
+        
+def check_solr_connection(retry=None):
+
+    if retry is None:
+        retry = RETRY
+    elif retry == 0:
+        print '[prerun] Giving up after 5 tries...'
+        sys.exit(1)
+
+    url = os.environ.get('DEV_CKAN_SOLR_URL', '')
+    search_url = '{url}/select/?q=*&wt=json'.format(url=url)
+
+    try:
+        connection = urllib2.urlopen(search_url)
+    except urllib2.URLError as e:
+        print str(e)
+        print '[prerun] Unable to connect to solr, waiting...'
+        time.sleep(10)
+        check_solr_connection(retry=retry - 1)
+    else:
+        eval(connection.read())
+
+
+def init_db(ini=ckan_ini):
+
+    db_command = ['paster', '--plugin=ckan', 'db', 'init', '-c', ini]
+    print '[prerun] Initializing or upgrading db - start: {}'.format(ini)
+    try:
+        subprocess.check_output(db_command, stderr=subprocess.STDOUT)
+        print '[prerun] Initializing or upgrading db - end'
+    except subprocess.CalledProcessError, e:
+        if 'OperationalError' in e.output:
+            print e.output
+            print '[prerun] Database not ready, waiting a bit before exit...'
+            time.sleep(5)
+            sys.exit(1)
+        else:
+            print e.output
+            raise e
+
+
+def init_datastore_db():
+
+    conn_str = os.environ.get('CKAN_DATASTORE_WRITE_URL')
+    if not conn_str:
+        print '[prerun] Skipping datastore initialization'
+        return
+
+    datastore_perms_command = ['paster', '--plugin=ckan', 'datastore',
+                               'set-permissions', '-c', ckan_ini]
+
+    connection = psycopg2.connect(conn_str)
+    cursor = connection.cursor()
+
+    print '[prerun] Initializing datastore db - start'
+    try:
+        datastore_perms = subprocess.Popen(
+            datastore_perms_command,
+            stdout=subprocess.PIPE)
+
+        perms_sql = datastore_perms.stdout.read()
+        # Remove internal pg command as psycopg2 does not like it
+        perms_sql = re.sub('\\\\connect \"(.*)\"', '', perms_sql)
+        cursor.execute(perms_sql)
+        for notice in connection.notices:
+            print notice
+
+        connection.commit()
+
+        print '[prerun] Initializing datastore db - end'
+        print datastore_perms.stdout.read()
+    except psycopg2.Error as e:
+        print '[prerun] Could not initialize datastore'
+        print str(e)
+
+    except subprocess.CalledProcessError, e:
+        if 'OperationalError' in e.output:
+            print e.output
+            print '[prerun] Database not ready, waiting a bit before exit...'
+            time.sleep(5)
+            sys.exit(1)
+        else:
+            print e.output
+            raise e
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def create_sysadmin():
+
+    name = os.environ.get('CKAN_SYSADMIN_NAME')
+    password = os.environ.get('CKAN_SYSADMIN_PASSWORD')
+    email = os.environ.get('CKAN_SYSADMIN_EMAIL')
+
+    if name and password and email:
+
+        # Check if user exists
+        command = ['paster', '--plugin=ckan', 'user', name, '-c', ckan_ini]
+
+        out = subprocess.check_output(command)
+        if 'User:None' not in re.sub(r'\s', '', out):
+            print '[prerun] Sysadmin user exists, skipping creation'
+            return
+
+        # Create user
+        command = ['paster', '--plugin=ckan', 'user', 'add',
+                   name,
+                   'password=' + password,
+                   'email=' + email,
+                   '-c', ckan_ini]
+
+        subprocess.call(command)
+        print '[prerun] Created user {0}'.format(name)
+
+        # Make it sysadmin
+        command = ['paster', '--plugin=ckan', 'sysadmin', 'add',
+                   name,
+                   '-c', ckan_ini]
+
+        subprocess.call(command)
+        print '[prerun] Made user {0} a sysadmin'.format(name)
+
+
+if __name__ == '__main__':
+
+    maintenance = os.environ.get('MAINTENANCE_MODE', '').lower() == 'true'
+
+    if maintenance:
+        print '[prerun] Maintenance mode, skipping setup...'
+    else:
+        check_main_db_connection()
+        init_db()
+        init_db(ini=test_ckan_ini)
+        update_plugins()
+        check_datastore_db_connection()
+        init_datastore_db()
+        create_sysadmin()
+        check_solr_connection()

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -8,7 +8,6 @@ if [[ ! -z $1 && $1 == '2.8' ]]; then
     CKAN_VERSION=2.8.3-dgu
     CKAN_FORK=alphagov
     SRC_DIR=2.8
-    DATAGOVUK_BRANCH=master-2.8
 elif [[ ! -z $1 && $1 == '2.9' ]]; then
     CKAN_VERSION=2.9-dgu
     CKAN_FORK=alphagov

--- a/scripts/rebuild-ckan.sh
+++ b/scripts/rebuild-ckan.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 if [[ ! -z $1 && $1 == '2.8' ]]; then
     echo "=== Building CKAN 2.8 ==="
@@ -57,6 +58,6 @@ if [[ $BUILD == 'all' || $BUILD == 'main' || $BUILD == 'dev' ]]; then
 
 fi
 
-(cd ckan-postdev && docker build -t govuk/ckan-postdev:$VERSION -f $VERSION/Dockerfile .)
+(cd ckan-postdev && docker build $NO_CACHE -t govuk/ckan-postdev:$VERSION -f $VERSION/Dockerfile .)
 
 docker-compose -f docker-compose-$VERSION.yml $FULL_ARGS build


### PR DESCRIPTION
## What

Add test data in the setup of the docker ckan stack and update dockerfiles to make it easier to make changes to `prerun.py` without having to rebuild the entire docker ckan stack and update the `2.8` ckan projects  to use the alphagov fork as it contains some commits to handle reindexing.

## Reference

https://trello.com/c/pXX11t8Y/273-add-test-data-to-docker-ckan-stack