### PR TITLE
Update CKAN 2.9 projects for python 3

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,11 +10,15 @@ CKAN_SYSADMIN_NAME=ckan_admin
 CKAN_SYSADMIN_PASSWORD=test1234
 CKAN_SYSADMIN_EMAIL=your_email@example.com
 TZ=UTC
+# 2.9 stack needs CKAN_SITE_URL set
+CKAN_SITE_URL=http://localhost:5002
 
 # Database connections (TODO: avoid duplication)
 DEV_CKAN_SQLALCHEMY_URL=postgresql://ckan:ckan@db/ckan
 CKAN_DATASTORE_WRITE_URL=postgresql://ckan:ckan@db/datastore
 CKAN_DATASTORE_READ_URL=postgresql://datastore_ro:datastore@db/datastore
+# 2.9 stack needs CKAN_SQLALCHEMY_URL set
+CKAN_SQLALCHEMY_URL=postgresql://ckan:ckan@db/ckan
 
 # DGU Publish and Find settings
 CKAN_URL=http://ckan-postdev:5000
@@ -36,8 +40,9 @@ DEV_CKAN_SOLR_URL=http://solr:8983/solr/ckan
 DEV_CKAN_REDIS_URL=redis://redis:6379/1
 CKAN_DATAPUSHER_URL=http://datapusher:8800
 CKAN__DATAPUSHER__CALLBACK_URL_BASE=http://ckan:5000
-# 2.9 stack needs CKAN_SOLR_URL set
+# 2.9 stack needs CKAN_SOLR_URL and CKAN_REDIS_URL set
 CKAN_SOLR_URL=http://solr:8983/solr/ckan
+CKAN_REDIS_URL=redis://redis:6379/1
 
 TEST_CKAN_SITE_URL=http://test.ckan.net
 TEST_CKAN_SOLR_URL=http://solr:8983/solr/ckan

--- a/README.md
+++ b/README.md
@@ -112,8 +112,15 @@ to pass in args
 
 ### Updating CKAN configuration, production.ini
 
-When you have to make changes to the CKAN config file, `production.ini`, update the `production.ini` file located in `ckan-main/setup` project to get a faster turn around time. Changing it on `ckan-base/setup` will increase the turn around time to more than 10 minutes rather than under 5 minutes within the `ckan-main` project. `production.ini` has been left in `ckan-base` because the Dockerfile in `ckan-base` has references to it. You will also need to run `./scripts/rebuild-ckan.sh main` in order to rebuild the image from your local changes rather than
-use the image in docker hub.
+When you have to make changes to the CKAN config file, `production.ini`, update the `production.ini` file located in `ckan-main/setup` project to get a faster turn around time. Changing it on `ckan-base/setup` will increase the turn around time to more than 10 minutes rather than under 5 minutes within the `ckan-main` project. `production.ini` has been left in `ckan-base` because the Dockerfile in `ckan-base` has references to it. You will also need to run `./scripts/rebuild-ckan.sh main` in order to rebuild the image from your local changes rather than use the image in docker hub.
+
+### Updating code in CKAN and its extensions
+
+Sometimes the changes made on your local machine won't be reflected in the docker container, so in order to copy these changes across you can use this command:
+
+`export CKANEXT_SRC=<CKAN extension, eg datagovuk> && sudo rsync -avz --update --existing --progress ./src_extensions/ckanext-$CKANEXT_SRC/ ./src/ckanext-$CKANEXT_SRC/`
+
+This should pick up any changes that match existing files to `/srv/app/src/<CKAN extension>`, any files that you added will have to be manually copied across. If you want to copy over everything regardless then simply remove `--existing` from the command.
 
 ### Useful tips during development
 

--- a/ckan-base/2.9/Dockerfile
+++ b/ckan-base/2.9/Dockerfile
@@ -1,5 +1,4 @@
-# FROM alpine:3.7
-FROM govuk/alpine-geos
+FROM govuk/trusty-python3:3.6
 
 # Internals, you probably don't need to change these
 ENV APP_DIR=/srv/app
@@ -9,71 +8,70 @@ ENV TEST_CKAN_INI=${SRC_DIR}/ckan/test-core.ini
 ENV PIP_SRC=${SRC_DIR}
 ENV CKAN_STORAGE_PATH=/var/lib/ckan
 
-# ckan 2.9 release tag
+# Set up virtual env as part of PATH so users don't need to activate venv
+ENV VIRTUAL_ENV=${APP_DIR}/venv
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
+
+# ckan 2.9.1 release tag
 ENV GIT_URL=https://github.com/ckan/ckan.git
-ENV GIT_SHA=ba0120dc0c798bbc9b6d8e9ad83db01a197ea179
+ENV GIT_SHA=bb272bfc7167b35cbff8ce48ed815dd4e23597ba
 
 WORKDIR ${APP_DIR}
 
 # Install necessary packages to run CKAN
-RUN apk add --no-cache tzdata \
+RUN apt-get -y install tzdata \
         git \
         gettext \
         postgresql-client \
-        python \
         apache2-utils \
         libxml2 \
-        libxslt \
+        libxslt1.1 \
         musl-dev \
         uwsgi \
-        uwsgi-http \
-        uwsgi-corerouter \
-        uwsgi-python \
-        py2-gevent \
-        uwsgi-gevent \
-        libmagic \
+        libmagic-dev \
         curl \
         vim \
         sudo && \
     # Packages to build CKAN requirements and plugins
-    apk add --no-cache --virtual .build-deps \
-        postgresql-dev \
+    sudo apt-get -y install \
         gcc \
         make \
         g++ \
         autoconf \
         automake \
         libtool \
-        python-dev \
         libxml2-dev \
         libxslt-dev \
-        linux-headers && \
+        linux-headers-generic-lts-vivid && \
     # Create SRC_DIR
     mkdir -p ${SRC_DIR} && \
     # Install pip, supervisord and uwsgi
-    curl -o ${SRC_DIR}/get-pip.py https://bootstrap.pypa.io/get-pip.py && \
-    python ${SRC_DIR}/get-pip.py && \
-    pip install supervisor && \
-    mkdir /etc/supervisord.d && \
-    #pip wheel --wheel-dir=/wheels uwsgi gevent && \
-    rm -rf ${SRC_DIR}/get-pip.py
+    mkdir /etc/supervisord.d
 
-# RUN echo "@testing http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories && \
-#     apk add --update --no-cache geos@testing geos-dev@testing
+# Install CKAN
+RUN python3.6 -m venv ${VIRTUAL_ENV} && \
+    pip install supervisor && \
+    pip install -e git+${GIT_URL}@${GIT_SHA}#egg=ckan && \
+    cd ${SRC_DIR}/ckan && \
+    cp who.ini ${APP_DIR} && \
+    pip install --no-binary :all: -r requirements.txt && \
+    # Install CKAN envvars to support loading config from environment variables
+    pip install -e git+https://github.com/okfn/ckanext-envvars.git#egg=ckanext-envvars && \
+    ckan generate config ${CKAN_INI} && \
+    ## code to handle problem with config-tool - https://github.com/ckan/ckan/issues/5568
+    # site url can't be set with the config tool
+    echo "*** using hack for ckan.site_url" && \
+    perl -pi -e "s|^(ckan.site_url =)$|\1 ${DEV_CKAN_SITE_URL}|;" $CKAN_INI && \
+    ## end hack
+    ckan config-tool ${CKAN_INI} "ckan.plugins=${CKAN__PLUGINS}"
 
 COPY setup/supervisord.conf /etc
 
-# Install CKAN
-RUN pip install -e git+${GIT_URL}@${GIT_SHA}#egg=ckan && \
-    cd ${SRC_DIR}/ckan && \
-    cp who.ini ${APP_DIR} && \
-    pip install --no-binary :all: -r requirements-py2.txt && \
-    # Install CKAN envvars to support loading config from environment variables
-    pip install -e git+https://github.com/okfn/ckanext-envvars.git#egg=ckanext-envvars
-
 # Create a local user and group to run the app
-RUN addgroup -g 92 -S ckan && \
-    adduser -u 92 -h /srv/app -H -D -S -G ckan ckan
+RUN groupadd -g 92 ckan && \
+    useradd -u 92 -d /srv/app -m -g ckan ckan
 
 # Create local storage folder
 RUN mkdir -p $CKAN_STORAGE_PATH && \
@@ -81,9 +79,8 @@ RUN mkdir -p $CKAN_STORAGE_PATH && \
 
 COPY setup ${APP_DIR}
 COPY setup/prerun-2.9.py ${APP_DIR}/prerun.py
-COPY setup/ckan_harvesting.conf /etc/supervisord.d/ckan_harvesting.conf
+COPY setup/ckan_harvesting-2.9.conf /etc/supervisord.d/ckan_harvesting.conf
 COPY setup/supervisor.worker-2.9.conf /etc/supervisord.d/worker.conf
-COPY setup/uwsgi.conf /srv/app/uwsgi.conf
 
 # Create entrypoint directory for children image scripts
 ONBUILD RUN mkdir /docker-entrypoint.d
@@ -91,5 +88,3 @@ ONBUILD RUN mkdir /docker-entrypoint.d
 RUN chown ckan -R /srv/app
 
 HEALTHCHECK --interval=10s --timeout=5s --retries=5 CMD curl --fail http://localhost:$CKAN_PORT/api/3/action/status_show || exit 1
-
-CMD ["/srv/app/start_ckan.sh"]

--- a/ckan-base/setup/ckan_harvesting-2.9.conf
+++ b/ckan-base/setup/ckan_harvesting-2.9.conf
@@ -1,0 +1,31 @@
+; ===============================
+; ckan harvester
+; ===============================
+
+[program:ckan_gather_consumer]
+
+command=ckan -c /srv/app/production.ini harvester gather_consumer
+
+; user that owns virtual environment.
+user=ckan
+
+numprocs=1
+stdout_logfile=/var/log/ckan/gather_consumer.log
+stderr_logfile=/var/log/ckan/gather_consumer.err.log
+autostart=true
+autorestart=true
+startsecs=10
+
+[program:ckan_fetch_consumer]
+
+command=ckan -c /srv/app/production.ini harvester fetch_consumer
+
+; user that owns virtual environment.
+user=ckan
+
+numprocs=1
+stdout_logfile=/var/log/ckan/fetch_consumer.log
+stderr_logfile=/var/log/ckan/fetch_consumer.err.log
+autostart=true
+autorestart=true
+startsecs=10

--- a/ckan-dev/2.9/Dockerfile
+++ b/ckan-dev/2.9/Dockerfile
@@ -1,40 +1,15 @@
 FROM govuk/ckan-base:2.9
 
-MAINTAINER Open Knowledge International <info@okfn.org>
+LABEL maintainer="team@data.gov.uk"
 
 ENV APP_DIR=/srv/app
 ENV SRC_EXTENSIONS_DIR=/srv/app/src_extensions
 
-# Install packages needed by the dev requirements
-RUN apk add --no-cache libffi-dev
-
-RUN pip install --upgrade pip
-
 # Install CKAN dev requirements
-# pip install is unable to install pytest-split-tests from dev-requirements.txt so install it manually
-RUN pip install pytest-split-tests==1.0.9
-
-RUN pip install --no-binary :all: -r $SRC_DIR/ckan/requirements-py2.txt
 RUN pip install -r $SRC_DIR/ckan/dev-requirements.txt
-RUN pip install six==1.13.0
-RUN pip install cryptography==2.8
 
 # Create ckan log dir
 RUN mkdir -p /var/log/ckan
-
-# RUN pip install configparser && \
-#     ckan generate config ${CKAN_INI} && \
-#     ckan config-tool ${CKAN_INI} "ckan.plugins=${CKAN__PLUGINS}" && \
-#     ckan config-tool ${CKAN_INI} "ckan.site_url=${CKAN__SITE_URL}" 
-
-    # Upgrade pylons version as the bundled version specified in requirements-py2.txt does not work
-# RUN pip install Pylons==1.0.3 && \
-#     # webob version installed is not high enough as lacks some dependencies
-#     pip install webob==1.8.6 && \
-#     # cryptography 2.9 is broken with this error message
-#     # ImportError: Error relocating /usr/lib/python2.7/site-packages/cryptography/hazmat/bindings/_openssl.so: RSA_get0_crt_params: symbol not found
-#     # so set to cryptography 2.8
-#     pip install cryptography==2.8
 
 # Create folder for local extensions sources
 RUN mkdir $SRC_EXTENSIONS_DIR

--- a/ckan-dev/setup/init_config-2.9.sh
+++ b/ckan-dev/setup/init_config-2.9.sh
@@ -24,3 +24,22 @@ ckan config-tool $CKAN_INI \
   "ckan.datagovuk.s3_bucket_name = $CKAN_S3_BUCKET_NAME" \
   "ckan.datagovuk.s3_url_prefix = $CKAN_S3_URL_PREFIX" \
   "ckan.datagovuk.s3_aws_region_name = $CKAN_S3_AWS_REGION_NAME"
+
+# update test.ini in ckan and extensions
+for i in $SRC_EXTENSIONS_DIR/*
+do
+    if [ -d $i ] && (
+        [ -z "$DEV_EXTENSIONS_WHITELIST" ] || [[ ",$DEV_EXTENSIONS_WHITELIST," =~ ",$(basename $i)," ]]
+    );
+    then
+        if [ -f $i/test.ini ]; then
+            echo "=== Updating test config in $i"
+            ckan config-tool $i/test.ini \
+                "use = config:../../src/ckan/test-core.ini" \
+                "sqlalchemy.url = $TEST_CKAN_SQLALCHEMY_URL" \
+                "ckan.site_url = $TEST_CKAN_SITE_URL" \
+                "solr_url = $TEST_CKAN_SOLR_URL" \
+                "ckan.redis.url = $TEST_CKAN_REDIS_URL"
+        fi
+    fi
+done

--- a/ckan-dev/setup/init_config-2.9.sh
+++ b/ckan-dev/setup/init_config-2.9.sh
@@ -18,7 +18,7 @@ ckan config-tool $SRC_DIR/ckan/test-core.ini \
     "solr_url = $TEST_CKAN_SOLR_URL" \
     "ckan.redis.url = $TEST_CKAN_REDIS_URL"
 
-ckan config-tool $APP_DIR/production.ini \
+ckan config-tool $CKAN_INI \
   "ckan.datagovuk.s3_aws_access_key_id = $CKAN_S3_AWS_ACCESS_KEY_ID" \
   "ckan.datagovuk.s3_aws_secret_access_key = $CKAN_S3_AWS_SECRET_ACCESS_KEY" \
   "ckan.datagovuk.s3_bucket_name = $CKAN_S3_BUCKET_NAME" \

--- a/ckan-dev/setup/start_ckan_development-2.9.sh
+++ b/ckan-dev/setup/start_ckan_development-2.9.sh
@@ -1,24 +1,5 @@
 #!/bin/bash
 
-# additional requirements to install as the installation process on 2.9 is slightly broken
-# echo "*** install python2 and dev requirements"
-# pip install -r $SRC_DIR/ckan/requirements-py2.txt
-# pip install -r $SRC_DIR/ckan/dev-requirements.txt
-# pip install six==1.13.0
-# pip install cryptography==2.8
-
-# Initialise CKAN config
-
-ckan generate config ${CKAN_INI}
-
-## code to handle problem with config-tool - https://github.com/ckan/ckan/issues/5568
-# site url can't be set with the config tool
-echo "*** using hack for ckan.site_url"
-perl -pi -e "s|^(ckan.site_url =)$|\1 ${DEV_CKAN_SITE_URL}|;" $CKAN_INI
-## end hack
-
-ckan config-tool ${CKAN_INI} "ckan.plugins=${CKAN__PLUGINS}"
-ckan config-tool ${CKAN_INI} "ckan.site_url=${DEV_CKAN_SITE_URL}" 
 
 # Install any local extensions in the src_extensions volume
 echo "Looking for local extensions to install..."
@@ -119,7 +100,7 @@ if [[ $START_CKAN = 1 ]]; then
     # supervisord --configuration /etc/supervisord.conf &
 
     # Start the development server with automatic reload
-    ckan run --host 0.0.0.0 --reloader $CKAN_INI
+    ckan -c $CKAN_INI run --host 0.0.0.0
 else
     # just to keep container running
     echo "Keeping container running..."

--- a/ckan-main/2.7/Dockerfile.dev
+++ b/ckan-main/2.7/Dockerfile.dev
@@ -12,7 +12,7 @@ RUN echo UTC > /etc/timezone
 ENV DCAT_SHA=b693bc911578cfc28e80c871d8e8eddb07411cfc
 ENV HARVEST_SHA=944f67c48d274df79a2719b5553698e3e6980a51
 ENV SPATIAL_SHA=f8bfb7501aaee49dd5a2419ba8785104c2f0d0a9
-ENV DATAGOVUK_VERSION=release_202
+ENV DATAGOVUK_SHA=03baa4f4b54dd8063b744b94a35e4e9dc6343599
 
 RUN which python && \
     pip install --upgrade setuptools && \
@@ -24,8 +24,8 @@ RUN which python && \
     pip install -r https://raw.githubusercontent.com/ckan/ckanext-harvest/$HARVEST_SHA/pip-requirements.txt && \
     pip install -e git+https://github.com/alphagov/ckanext-spatial.git@$SPATIAL_SHA#egg=ckanext-spatial && \
     pip install -r https://raw.githubusercontent.com/alphagov/ckanext-spatial/$SPATIAL_SHA/pip-requirements.txt && \
-    pip install -e git://github.com/alphagov/ckanext-datagovuk.git@$DATAGOVUK_VERSION#egg=ckanext-datagovuk && \
-    pip install -r https://raw.githubusercontent.com/alphagov/ckanext-datagovuk/$DATAGOVUK_VERSION/requirements.txt
+    pip install -e git://github.com/alphagov/ckanext-datagovuk.git@$DATAGOVUK_SHA#egg=ckanext-datagovuk && \
+    pip install -r https://raw.githubusercontent.com/alphagov/ckanext-datagovuk/$DATAGOVUK_SHA/requirements.txt
 
 # Clone the extension(s) your are writing for your own project in the `src` folder
 # to get them mounted in this image at runtime

--- a/ckan-main/2.9/Dockerfile.dev
+++ b/ckan-main/2.9/Dockerfile.dev
@@ -9,19 +9,17 @@ RUN echo UTC > /etc/timezone
 # Install any extensions needed by your CKAN instance
 # (Make sure to add the plugins to CKAN__PLUGINS in the .env file)
 
-ENV DCAT_SHA=b693bc911578cfc28e80c871d8e8eddb07411cfc
-ENV HARVEST_SHA=944f67c48d274df79a2719b5553698e3e6980a51
-ENV SPATIAL_SHA=f8bfb7501aaee49dd5a2419ba8785104c2f0d0a9
-ENV DATAGOVUK_VERSION=ckan-2.9
+ENV DCAT_SHA=6b7ec505f303fb18e0eebcebf67130d36b3dca82
+ENV HARVEST_SHA=0c5c05f9fddb8295a307ef990aa5e52f4cf0bf6d
+ENV SPATIAL_SHA=7684ef23a330e72512d4678da30165a5b97ca06f
+ENV DATAGOVUK_VERSION=python3
 
-RUN which python && \
-    pip install --upgrade setuptools && \
+RUN pip install --upgrade setuptools && \
     # install numpy outside of requirements.txt as was complaining of python 3.5 requirement
-    pip install numpy==1.16.4 && \
     pip install -e git+https://github.com/ckan/ckanext-dcat.git@$DCAT_SHA#egg=ckanext-dcat && \
     pip install -r https://raw.githubusercontent.com/ckan/ckanext-dcat/$DCAT_SHA/requirements.txt && \
-    pip install -e git+https://github.com/ckan/ckanext-harvest.git@$HARVEST_SHA#egg=ckanext-harvest && \
-    pip install -r https://raw.githubusercontent.com/ckan/ckanext-harvest/$HARVEST_SHA/pip-requirements.txt && \
+    pip install -e git+https://github.com/alphagov/ckanext-harvest.git@$HARVEST_SHA#egg=ckanext-harvest && \
+    pip install -r https://raw.githubusercontent.com/alphagov/ckanext-harvest/$HARVEST_SHA/pip-requirements.txt && \
     pip install -e git+https://github.com/alphagov/ckanext-spatial.git@$SPATIAL_SHA#egg=ckanext-spatial && \
     pip install -r https://raw.githubusercontent.com/alphagov/ckanext-spatial/$SPATIAL_SHA/pip-requirements.txt && \
     pip install -e git://github.com/alphagov/ckanext-datagovuk.git@$DATAGOVUK_VERSION#egg=ckanext-datagovuk && \
@@ -45,6 +43,9 @@ RUN for d in $APP_DIR/patches/*; do \
         fi ; \
     done
 
+# CKAN configuration, modify production.ini in this project to avoid rebuilding ckan-base and ckan-dev projects
+COPY setup/production-2.9.ini $APP_DIR/production.ini
+
 # Setup pycsw
 COPY setup/pycsw.cfg $APP_DIR/pycsw.cfg
 COPY setup/pycsw_supervisord.conf /etc/supervisord.d/pycsw_supervisord.conf
@@ -58,6 +59,3 @@ RUN cd $SRC_EXTENSIONS_DIR && git clone --branch 2.4.0 https://github.com/geopyt
     python setup.py install && \
     chown ckan $APP_DIR/pycsw.cfg && \
     chmod 644 $APP_DIR/pycsw.cfg
-
-# CKAN configuration, modify production.ini in this project to avoid rebuilding ckan-base and ckan-dev projects
-COPY setup/production-2.9.ini $APP_DIR/production.ini

--- a/ckan-main/docker-entrypoint.d/2.9/setup_datagovuk.sh
+++ b/ckan-main/docker-entrypoint.d/2.9/setup_datagovuk.sh
@@ -7,5 +7,5 @@ ckan config-tool $SRC_EXTENSIONS_DIR/ckanext-datagovuk/test.ini \
     "sqlalchemy.url = $TEST_CKAN_SQLALCHEMY_URL"
 
 echo "Setup test data"
-paster --plugin=ckanext-datagovuk remove_dgu_test_data -c $CKAN_INI
-paster --plugin=ckanext-datagovuk create_dgu_test_data -c $CKAN_INI
+ckan -c $CKAN_INI datagovuk remove-dgu-test-data
+ckan -c $CKAN_INI datagovuk create-dgu-test-data

--- a/ckan-main/docker-entrypoint.d/2.9/setup_harvest.sh
+++ b/ckan-main/docker-entrypoint.d/2.9/setup_harvest.sh
@@ -2,7 +2,7 @@
 
 echo "====== Set up Harvest ======"
 
-ckanext-harvest harvester initdb -c "$CKAN_INI"
+ckan -c "$CKAN_INI" harvester initdb
 
 echo "Loading test settings into harvest test-core.ini"
 

--- a/ckan-main/docker-entrypoint.d/2.9/setup_pycsw.sh
+++ b/ckan-main/docker-entrypoint.d/2.9/setup_pycsw.sh
@@ -3,7 +3,7 @@
 echo "====== set up pycsw ======"
 
 cd $SRC_EXTENSIONS_DIR/ckanext-spatial
-paster --plugin=ckanext-spatial ckan-pycsw setup -p $APP_DIR/pycsw.cfg
+ckan -c "$CKAN_INI" spatial ckan-pycsw setup -p $APP_DIR/pycsw.cfg
 
 echo "Update pycsw abstract index to allow for larger records"
 PGPASSWORD=ckan psql pycsw -h db -U ckan -c "DROP INDEX ix_records_abstract;CREATE INDEX ix_records_abstract ON records((md5(abstract)));"

--- a/ckan-main/docker-entrypoint.d/2.9/setup_spatial.sh
+++ b/ckan-main/docker-entrypoint.d/2.9/setup_spatial.sh
@@ -2,6 +2,6 @@
 
 echo "====== Set up Spatial database ======"
 
-paster --plugin=ckanext-spatial spatial initdb -c "$CKAN_INI"
+ckan -c "$CKAN_INI" spatial initdb
 
 PGPASSWORD=ckan psql -h db -U ckan -d ckan_test -c "CREATE EXTENSION IF NOT EXISTS postgis;"

--- a/docker-compose-2.7.yml
+++ b/docker-compose-2.7.yml
@@ -52,7 +52,7 @@ services:
     ports:
       - "8983:8983"
     volumes:
-      - solr_data:/opt/solr/server/solr/ckan/data/index
+      - solr_data:/opt/solr/server/solr/ckan/data
     networks:
     - ckan-2.7
   

--- a/docker-compose-2.8.yml
+++ b/docker-compose-2.8.yml
@@ -52,7 +52,7 @@ services:
     ports:
       - "8984:8983"
     volumes:
-      - solr_data-2.8:/opt/solr/server/solr/ckan/data/index
+      - solr_data-2.8:/opt/solr/server/solr/ckan/data
     networks:
       - ckan-2.8
   

--- a/govuk-python3/Dockerfile
+++ b/govuk-python3/Dockerfile
@@ -1,0 +1,19 @@
+FROM ubuntu:trusty
+
+RUN apt-get update
+RUN apt-get -y install libpq-dev \
+        libgeos-dev \
+        libssl-dev \
+        libffi-dev \
+        build-essential \
+        wget
+
+RUN apt-get -y install software-properties-common && \
+    add-apt-repository ppa:deadsnakes/ppa && \
+    apt-get update && \
+    apt-get -y install python3.6 \
+        python3.6-dev \
+        python3-setuptools \
+        python3.6-venv && \
+    easy_install3 pip && \
+    sudo update-alternatives --install /usr/bin/python python /usr/bin/python3.6 10

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -3,6 +3,9 @@
 # Default git fork
 CKAN_FORK=ckan
 DATAGOVUK_BRANCH=master
+SPATIAL_BRANCH=master
+HARVEST_FORK=ckan
+HARVEST_BRANCH=master
 
 if [[ ! -z $1 && $1 == '2.8' ]]; then
     CKAN_VERSION=2.8.3-dgu
@@ -10,10 +13,11 @@ if [[ ! -z $1 && $1 == '2.8' ]]; then
     SRC_DIR=2.8
     DATAGOVUK_BRANCH=master
 elif [[ ! -z $1 && $1 == '2.9' ]]; then
-    # CKAN_VERSION=2.9-dgu
-    # CKAN_FORK=alphagov
-    DATAGOVUK_BRANCH=ckan-2.9
-    CKAN_VERSION=2.9.0
+    DATAGOVUK_BRANCH=python3
+    HARVEST_FORK=alphagov
+    HARVEST_BRANCH=fix-run_test
+    SPATIAL_BRANCH=python3
+    CKAN_VERSION=2.9.1
     CKAN_FORK=ckan
     SRC_DIR=2.9
 else
@@ -26,11 +30,11 @@ echo -e "Please ensure that the ${SRC_DIR} src directory is empty before running
 
 mkdir -p src/$SRC_DIR
 pushd src/$SRC_DIR
-git clone --branch ckan-$CKAN_VERSION https://github.com/$CKAN_FORK/ckan
+git clone https://github.com/$CKAN_FORK/ckan --branch ckan-$CKAN_VERSION
 
-git clone --branch $DATAGOVUK_BRANCH https://github.com/alphagov/ckanext-datagovuk
-git clone https://github.com/ckan/ckanext-harvest
-git clone https://github.com/alphagov/ckanext-spatial
+git clone https://github.com/alphagov/ckanext-datagovuk --branch $DATAGOVUK_BRANCH 
+git clone https://github.com/$HARVEST_FORK/ckanext-harvest --branch $HARVEST_BRANCH
+git clone https://github.com/alphagov/ckanext-spatial --branch $SPATIAL_BRANCH
 git clone https://github.com/ckan/ckanext-dcat
 git clone https://github.com/geopython/pycsw.git --branch 2.4.0 
 

--- a/scripts/rebuild-ckan.sh
+++ b/scripts/rebuild-ckan.sh
@@ -44,13 +44,13 @@ elif [[ ! -z $2 && $2 != 'full' ]]; then
     fi
 fi
 
-if [[ $BUILD == 'all' || $BUILD == 'main' || $BUILD == 'dev' ]]; then
+if [[ $BUILD == 'all' || $BUILD == 'base' || $BUILD == 'main' || $BUILD == 'dev' ]]; then
 
-    if [[ $BUILD == 'all' ]]; then
+    if [[ $BUILD == 'all' || $BUILD == 'base' ]]; then
         (cd ckan-base && docker build $NO_CACHE -t govuk/ckan-base:$VERSION -f $VERSION/Dockerfile .)
     fi
 
-    if [[ $BUILD == 'all' || $BUILD == 'dev' ]]; then
+    if [[ $BUILD == 'all' || $BUILD == 'base' || $BUILD == 'dev' ]]; then
         (cd ckan-dev && docker build $NO_CACHE -t govuk/ckan-dev:$VERSION -f $VERSION/Dockerfile .)
     fi
 

--- a/solr/schema.xml
+++ b/solr/schema.xml
@@ -164,8 +164,6 @@ schema. In this case the version should be set to the next CKAN version number.
 </fields>
 
 <uniqueKey>index_id</uniqueKey>
-<defaultSearchField>text</defaultSearchField>
-<solrQueryParser defaultOperator="AND"/>
 
 <copyField source="url" dest="urls"/>
 <copyField source="ckan_url" dest="urls"/>

--- a/solr/solrconfig.xml
+++ b/solr/solrconfig.xml
@@ -80,6 +80,8 @@
 		<lst name="defaults">
 			<str name="echoParams">explicit</str>
 			<int name="rows">10</int>
+			<str name="df">text</str>
+			<str name="q.op">AND</str>
 		</lst>
 		
 	</requestHandler>


### PR DESCRIPTION
## What

Updates the 2.9 projects to work on trusty python 3.

Also includes an update to the README to synchronise files manually when the files changes locally are not reflected back on the container.