### PR TITLE
Add test data variables for creating test data in ckan

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -71,3 +71,7 @@ CKAN_S3_AWS_SECRET_ACCESS_KEY=dummy_value
 CKAN_S3_BUCKET_NAME=dummy_value
 CKAN_S3_URL_PREFIX=dummy_value
 CKAN_S3_AWS_REGION_NAME=dummy_value
+
+# test data credentials
+CKAN_TEST_SYSADMIN_NAME=ckan_admin_test
+CKAN_TEST_SYSADMIN_PASSWORD=test1234


### PR DESCRIPTION
## What
Adds the `CKAN_TEST_SYSADMIN_NAME` and `CKAN_TEST_SYSADMIN_PASSWORD` env variables to `.env.example`.

## Why
This is required for the test data generation jobs as part of the docker-ckan startup script. Putting it in the .env means it no longer needs to be set in the docker container.