### PR TITLE
Update 2.9 setup to enable 2.9 tests to pass

### DIFF
--- a/ckan-dev/setup/init_config-2.9.sh
+++ b/ckan-dev/setup/init_config-2.9.sh
@@ -35,7 +35,7 @@ do
         if [ -f $i/test.ini ]; then
             echo "=== Updating test config in $i"
             ckan config-tool $i/test.ini \
-                "use = config:../../src/ckan/test-core.ini" \
+                "use = config:$SRC_DIR/ckan/test-core.ini" \
                 "sqlalchemy.url = $TEST_CKAN_SQLALCHEMY_URL" \
                 "ckan.site_url = $TEST_CKAN_SITE_URL" \
                 "solr_url = $TEST_CKAN_SOLR_URL" \

--- a/ckan-dev/setup/start_ckan_development-2.9.sh
+++ b/ckan-dev/setup/start_ckan_development-2.9.sh
@@ -12,7 +12,10 @@ do
     elif [ -d $i ] && ([ -z "$DEV_EXTENSIONS_WHITELIST" ] || [[ ",$DEV_EXTENSIONS_WHITELIST," =~ ",$(basename $i)," ]]);
     then
 
-        if [ -f $i/pip-requirements.txt ];
+        if [ -f $i/pip3-requirements.txt ];
+        then
+            pip install -r $i/pip3-requirements.txt
+        elif [ -f $i/pip-requirements.txt ];
         then
             pip install -r $i/pip-requirements.txt
             echo "Found requirements file in $i"
@@ -77,6 +80,12 @@ ckan config-tool $APP_DIR/production.ini \
 
 # Run the prerun script to init CKAN and create the default admin user
 python prerun.py
+
+# initialise the CKAN and extension configs
+source ./init_config.sh
+
+# drop postgis extension and log_level type from test database to enable tests to run
+PGPASSWORD=ckan psql -h db -U ckan -d ckan_test -c "DROP EXTENSION IF EXISTS postgis CASCADE; DROP TYPE IF EXISTS log_level CASCADE;"
 
 # Run any startup scripts provided by images extending this one
 if [[ -d "/docker-entrypoint.d" ]]

--- a/ckan-main/docker-entrypoint.d/2.9/setup_cronjobs.sh
+++ b/ckan-main/docker-entrypoint.d/2.9/setup_cronjobs.sh
@@ -8,4 +8,4 @@ echo "*/30 * * * * ckan -c $CKAN_INI harvester clean-harvest-log" >> /etc/cronta
 echo "*/5 * * * * ckan -c $CKAN_INI search-index rebuild -o" >> /etc/crontab
 
 # pycsw load
-echo "*/5 * * * * ckan -c $CKAN_INI spatial-csw load -p $APP_DIR/pycsw.cfg -u http://localhost:5000" >> /etc/crontab
+echo "*/5 * * * * ckan -c $CKAN_INI ckan-pycsw load -p $APP_DIR/pycsw.cfg -u http://localhost:5000" >> /etc/crontab

--- a/ckan-main/docker-entrypoint.d/2.9/setup_datagovuk.sh
+++ b/ckan-main/docker-entrypoint.d/2.9/setup_datagovuk.sh
@@ -5,8 +5,8 @@ echo "====== Set up Data.gov.uk ======"
 echo "Update datagovuk SQLAlchemy URL"
 ckan config-tool $SRC_EXTENSIONS_DIR/ckanext-datagovuk/test.ini \
     "sqlalchemy.url = $TEST_CKAN_SQLALCHEMY_URL" \
-    # "solr_url = $TEST_CKAN_SOLR_URL" \
-    "ckan.redis.url = $TEST_CKAN_REDIS_URL"
+    "ckan.redis.url = $TEST_CKAN_REDIS_URL" \
+    "solr_url = $TEST_CKAN_SOLR_URL"
 
 echo "Setup test data"
 ckan -c $CKAN_INI datagovuk remove-dgu-test-data

--- a/ckan-main/docker-entrypoint.d/2.9/setup_dcat.sh
+++ b/ckan-main/docker-entrypoint.d/2.9/setup_dcat.sh
@@ -2,6 +2,10 @@
 
 echo "====== Set up Dcat ======"
 
+echo "Loading test settings into dcat test-core.ini"
+ckan config-tool $SRC_EXTENSIONS_DIR/ckanext-dcat/test.ini \
+    "use = config:$SRC_DIR/ckan/test-core.ini"
+
 echo "Update Dcat Solr URL"
 ckan config-tool $SRC_EXTENSIONS_DIR/ckanext-dcat/test.ini \
     "solr_url = $TEST_CKAN_SOLR_URL"

--- a/ckan-main/docker-entrypoint.d/2.9/setup_harvest.sh
+++ b/ckan-main/docker-entrypoint.d/2.9/setup_harvest.sh
@@ -6,7 +6,7 @@ ckan -c "$CKAN_INI" harvester initdb
 
 echo "Loading test settings into harvest test-core.ini"
 
-ckan config-tool $SRC_EXTENSIONS_DIR/ckanext-harvest/test-core.ini \
+ckan config-tool $SRC_EXTENSIONS_DIR/ckanext-harvest/test.ini \
     "use = config:$SRC_DIR/ckan/test-core.ini"
 
 echo "Loading test settings into ckan test-core.ini"

--- a/ckan-main/docker-entrypoint.d/2.9/setup_pycsw.sh
+++ b/ckan-main/docker-entrypoint.d/2.9/setup_pycsw.sh
@@ -3,7 +3,7 @@
 echo "====== set up pycsw ======"
 
 cd $SRC_EXTENSIONS_DIR/ckanext-spatial
-ckan -c "$CKAN_INI" spatial-csw setup -p $APP_DIR/pycsw.cfg
+ckan -c "$CKAN_INI" ckan-pycsw setup -p $APP_DIR/pycsw.cfg
 
 echo "Update pycsw abstract index to allow for larger records"
 PGPASSWORD=ckan psql pycsw -h db -U ckan -c "DROP INDEX ix_records_abstract;CREATE INDEX ix_records_abstract ON records((md5(abstract)));"

--- a/ckan-main/docker-entrypoint.d/2.9/setup_spatial.sh
+++ b/ckan-main/docker-entrypoint.d/2.9/setup_spatial.sh
@@ -1,7 +1,12 @@
 #!/bin/bash
 
-echo "====== Set up Spatial database ======"
+echo "====== Set up Spatial ======"
+
+echo "Update Spatial test ckan.site_url URL"
+
+ckan config-tool $SRC_EXTENSIONS_DIR/ckanext-spatial/test.ini \
+    "ckan.site_url = http://localhost"
+
+echo "Set up Spatial database"
 
 ckan -c "$CKAN_INI" spatial initdb
-
-PGPASSWORD=ckan psql -h db -U ckan -d ckan_test -c "CREATE EXTENSION IF NOT EXISTS postgis;"

--- a/ckan-main/setup/production-2.9.ini
+++ b/ckan-main/setup/production-2.9.ini
@@ -213,7 +213,7 @@ keys = console, file
 keys = generic
 
 [logger_root]
-level = WARNING
+level = INFO
 handlers = console, file
 ; handlers = console
 

--- a/ckan-main/setup/production.ini
+++ b/ckan-main/setup/production.ini
@@ -212,7 +212,7 @@ keys = console, file
 keys = generic
 
 [logger_root]
-level = WARNING
+level = INFO
 handlers = console, file
 ; handlers = console
 

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -3,6 +3,8 @@
 # Default git fork
 CKAN_FORK=ckan
 DATAGOVUK_BRANCH=master
+DCAT_FORK=ckan
+DCAT_BRANCH=master
 SPATIAL_BRANCH=master
 HARVEST_FORK=ckan
 HARVEST_BRANCH=master
@@ -20,6 +22,8 @@ elif [[ ! -z $1 && $1 == '2.9' ]]; then
     CKAN_VERSION=2.9.1
     CKAN_FORK=ckan
     SRC_DIR=2.9
+    DCAT_FORK=alphagov
+    DCAT_BRANCH=update-test-harvester
 else
     CKAN_VERSION=2.8.3-dgu
     CKAN_FORK=alphagov
@@ -36,7 +40,7 @@ git clone https://github.com/$CKAN_FORK/ckan --branch ckan-$CKAN_VERSION
 git clone https://github.com/alphagov/ckanext-datagovuk --branch $DATAGOVUK_BRANCH 
 git clone https://github.com/$HARVEST_FORK/ckanext-harvest --branch $HARVEST_BRANCH
 git clone https://github.com/$SPATIAL_FORK/ckanext-spatial --branch $SPATIAL_BRANCH
-git clone https://github.com/ckan/ckanext-dcat
+git clone https://github.com/$DCAT_FORK/ckanext-dcat --branch $DCAT_BRANCH
 git clone https://github.com/geopython/pycsw.git --branch 2.4.0 
 
 git clone https://github.com/alphagov/ckan-mock-harvest-sources.git

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -7,23 +7,24 @@ SPATIAL_BRANCH=master
 HARVEST_FORK=ckan
 HARVEST_BRANCH=master
 
-if [[ ! -z $1 && $1 == '2.8' ]]; then
-    CKAN_VERSION=2.8.3-dgu
-    CKAN_FORK=alphagov
-    SRC_DIR=2.8
-    DATAGOVUK_BRANCH=master
+if [[ ! -z $1 && $1 == '2.7' ]]; then
+    CKAN_VERSION=2.7.6
+    SRC_DIR=2.7
+    DATAGOVUK_BRANCH=ckan-2.7
 elif [[ ! -z $1 && $1 == '2.9' ]]; then
-    DATAGOVUK_BRANCH=python3
+    DATAGOVUK_BRANCH=master-2.9
     HARVEST_FORK=alphagov
-    HARVEST_BRANCH=fix-run_test
-    SPATIAL_BRANCH=python3
+    HARVEST_BRANCH=master
+    SPATIAL_FORK=alphagov
+    SPATIAL_BRANCH=main-2.9
     CKAN_VERSION=2.9.1
     CKAN_FORK=ckan
     SRC_DIR=2.9
 else
-    CKAN_VERSION=2.7.6
-    SRC_DIR=2.7
-    DATAGOVUK_BRANCH=ckan-2.7
+    CKAN_VERSION=2.8.3-dgu
+    CKAN_FORK=alphagov
+    SRC_DIR=2.8
+    DATAGOVUK_BRANCH=master
 fi
 
 echo -e "Please ensure that the ${SRC_DIR} src directory is empty before running this command. This command will not populate the directories required for this project to run effectively unless said directories are already empty or don't exist.\n"
@@ -34,7 +35,7 @@ git clone https://github.com/$CKAN_FORK/ckan --branch ckan-$CKAN_VERSION
 
 git clone https://github.com/alphagov/ckanext-datagovuk --branch $DATAGOVUK_BRANCH 
 git clone https://github.com/$HARVEST_FORK/ckanext-harvest --branch $HARVEST_BRANCH
-git clone https://github.com/alphagov/ckanext-spatial --branch $SPATIAL_BRANCH
+git clone https://github.com/$SPATIAL_FORK/ckanext-spatial --branch $SPATIAL_BRANCH
 git clone https://github.com/ckan/ckanext-dcat
 git clone https://github.com/geopython/pycsw.git --branch 2.4.0 
 


### PR DESCRIPTION
## What

Update the setup scripts to enable running of 2.9 tests and update the README with details on how to run them.
Production.ini has also been updated to provide more detailed logs.

## How to review

Best way to review is to probably try and spin up your own docker ckan 2.9 stack and then run the tests.

## Reference 

https://trello.com/c/1P0lzbwV/2288-run-tests-for-other-ckan-extensions

.