### PR TITLE
Update ckan 2.9.2

### DIFF
--- a/ckan-base/2.7/Dockerfile
+++ b/ckan-base/2.7/Dockerfile
@@ -50,8 +50,8 @@ RUN apk add --no-cache tzdata \
     # Create SRC_DIR
     mkdir -p ${SRC_DIR} && \
     # Install pip, supervisord and uwsgi
-    curl -o ${SRC_DIR}/get-pip.py https://bootstrap.pypa.io/get-pip.py && \
-    python ${SRC_DIR}/get-pip.py && \
+    curl -o ${SRC_DIR}/get-pip.py https://bootstrap.pypa.io/pip/2.7/get-pip.py && \
+    python ${SRC_DIR}/get-pip.py pip==20.3.4 && \
     pip install supervisor && \
     mkdir /etc/supervisord.d && \
     #pip wheel --wheel-dir=/wheels uwsgi gevent && \

--- a/ckan-base/2.8/Dockerfile
+++ b/ckan-base/2.8/Dockerfile
@@ -50,8 +50,8 @@ RUN apk add --no-cache tzdata \
     # Create SRC_DIR
     mkdir -p ${SRC_DIR} && \
     # Install pip, supervisord and uwsgi
-    curl -o ${SRC_DIR}/get-pip.py https://bootstrap.pypa.io/get-pip.py && \
-    python ${SRC_DIR}/get-pip.py && \
+    curl -o ${SRC_DIR}/get-pip.py https://bootstrap.pypa.io/pip/2.7/get-pip.py && \
+    python ${SRC_DIR}/get-pip.py pip==20.3.4 && \
     pip install supervisor && \
     mkdir /etc/supervisord.d && \
     #pip wheel --wheel-dir=/wheels uwsgi gevent && \

--- a/ckan-base/2.9/Dockerfile
+++ b/ckan-base/2.9/Dockerfile
@@ -1,6 +1,5 @@
 FROM govuk/python:3.6.12
 
-# Internals, you probably don't need to change these
 ENV APP_DIR=/srv/app
 ENV SRC_DIR=/srv/app/src
 ENV CKAN_INI=${APP_DIR}/production.ini
@@ -14,9 +13,9 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
 
-# ckan 2.9.1 release tag
 ENV GIT_URL=https://github.com/ckan/ckan.git
-ENV GIT_SHA=bb272bfc7167b35cbff8ce48ed815dd4e23597ba
+# ckan 2.9.2 release tag
+ENV GIT_SHA=1b6d91790cfa668a6226f366b91dde68ae5d84b9
 
 WORKDIR ${APP_DIR}
 
@@ -60,11 +59,6 @@ RUN python3.6 -m venv ${VIRTUAL_ENV} && \
     # Install CKAN envvars to support loading config from environment variables
     pip install -e git+https://github.com/okfn/ckanext-envvars.git#egg=ckanext-envvars && \
     ckan generate config ${CKAN_INI} && \
-    ## code to handle problem with config-tool - https://github.com/ckan/ckan/issues/5568
-    # site url can't be set with the config tool
-    echo "*** using hack for ckan.site_url" && \
-    perl -pi -e "s|^(ckan.site_url =)$|\1 ${DEV_CKAN_SITE_URL}|;" $CKAN_INI && \
-    ## end hack
     ckan config-tool ${CKAN_INI} "ckan.plugins=${CKAN__PLUGINS}"
 
 COPY setup/supervisord.conf /etc

--- a/ckan-main/2.9/Dockerfile.dev
+++ b/ckan-main/2.9/Dockerfile.dev
@@ -9,14 +9,13 @@ RUN echo UTC > /etc/timezone
 # Install any extensions needed by your CKAN instance
 # (Make sure to add the plugins to CKAN__PLUGINS in the .env file)
 
-ENV DCAT_SHA=6b7ec505f303fb18e0eebcebf67130d36b3dca82
+ENV DCAT_SHA=b3069e41578b82aef6919f4e53809088bc2c0ce1
 ENV HARVEST_SHA=283ac0498fd22056fb8572d49b25cd8492b7178f
-ENV SPATIAL_SHA=d8dd6bd910f08c1f5408487cf2a455fc8ac0a91b
-ENV DATAGOVUK_VERSION=python3
+ENV SPATIAL_SHA=d64fd925700990a352ef23ed180c47dbc7277138
+ENV DATAGOVUK_VERSION=master-2.9
 
 RUN pip install --upgrade setuptools && \
-    # install numpy outside of requirements.txt as was complaining of python 3.5 requirement
-    pip install -e git+https://github.com/ckan/ckanext-dcat.git@$DCAT_SHA#egg=ckanext-dcat && \
+    pip install -e git+https://github.com/alphagov/ckanext-dcat.git@$DCAT_SHA#egg=ckanext-dcat && \
     pip install -r https://raw.githubusercontent.com/ckan/ckanext-dcat/$DCAT_SHA/requirements.txt && \
     pip install -e git+https://github.com/alphagov/ckanext-harvest.git@$HARVEST_SHA#egg=ckanext-harvest && \
     pip install -r https://raw.githubusercontent.com/alphagov/ckanext-harvest/$HARVEST_SHA/pip-requirements.txt && \

--- a/docker-compose-2.9-full.yml
+++ b/docker-compose-2.9-full.yml
@@ -3,9 +3,11 @@ version: "3"
 services:
   elasticsearch-2.9:
     container_name: elasticsearch-2.9
-    image: docker.elastic.co/elasticsearch/elasticsearch:6.8.9
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.9.1
     environment:
       - node.name=elasticsearch
+      - discovery.type=single-node
+      - bootstrap.memory_lock=true
       - "ES_JAVA_OPTS=-Xms1g -Xmx1g"
     ulimits:
       memlock:

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -19,7 +19,7 @@ elif [[ ! -z $1 && $1 == '2.9' ]]; then
     HARVEST_BRANCH=master
     SPATIAL_FORK=alphagov
     SPATIAL_BRANCH=main-2.9
-    CKAN_VERSION=2.9.1
+    CKAN_VERSION=2.9.2
     CKAN_FORK=ckan
     SRC_DIR=2.9
     DCAT_FORK=alphagov


### PR DESCRIPTION
## What

Updated the 2.9 stack to get a full end to end working with Find and Publish, elasticsearch updated to be in line with production and ckan and extensions were updated to fix various issues discovered during testing.

Pip also had to be updated for 2.7 and 2.8 as the pip running on python 2.7 had to be installed from a different url.

## How to review

Best way to review is to get the 2.9 stack running and see the example datasets in CKAN and the Find app.

## Reference 

https://trello.com/c/iq6oz3CT/2412-investigate-why-ckan-api-response-extras-block-removed-and-fix-or-document-it