### PR TITLE
Update postgres 13

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ For example:
 
     for datagovuk:
 
-    (cd $SRC_EXTENSIONS_DIR/ckanext-<extension> && python -m pytest --ckan-ini=test.ini tests/<test file>::<class>.<test name> --disable-pytest-warnings -v)
+    (cd $SRC_EXTENSIONS_DIR/ckanext-datagovuk && python -m pytest --ckan-ini=test.ini tests/<test file>::<class>::<test name> --disable-pytest-warnings -v)
 
 For example:
 

--- a/docker-compose-2.9.yml
+++ b/docker-compose-2.9.yml
@@ -16,7 +16,7 @@ services:
     env_file:
       - .env-2.9
     links:
-      - db-2.9:db
+      - db-2.9-13:db
       - solr-2.9:solr
       - redis-2.9:redis
     ports:
@@ -26,25 +26,38 @@ services:
       - ckan_storage-2.9:/var/lib/ckan
       - ./logs/2.9:/var/log/ckan
     depends_on: 
-      - db-2.9
+      - db-2.9-13
       - solr-2.9
       - redis-2.9
       - static-mock-harvest-source-2.9
     command: bash -c "/srv/app/start_ckan_development.sh"
+    # command: bash -c "tail -f /dev/null"
     networks:
       - ckan-2.9
 
-  db-2.9:
-    container_name: db-2.9
+  # db-2.9:
+  #   container_name: db-2.9
+  #   env_file:
+  #     - .env-2.9
+  #   build:
+  #     context: postgresql/
+  #   volumes:
+  #     - pg_data-2.9:/var/lib/postgresql/data
+  #   networks:
+  #     - ckan-2.9
+
+  db-2.9-13:
+    container_name: db-2.9-13
     env_file:
       - .env-2.9
     build:
       context: postgresql/
+      dockerfile: Dockerfile.13
     volumes:
-      - pg_data-2.9:/var/lib/postgresql/data
+      - pg_data-2.9-13:/var/lib/postgresql/data
     networks:
       - ckan-2.9
-  
+
   solr-2.9:
     container_name: solr-2.9
     build:
@@ -58,7 +71,7 @@ services:
   
   redis-2.9:
     container_name: redis-2.9
-    image: redis:alpine
+    image: redis:6.2.5-alpine3.14
     networks:
       - ckan-2.9
     volumes:
@@ -92,7 +105,8 @@ services:
 
 volumes:
   ckan_storage-2.9:
-  pg_data-2.9:
+  # pg_data-2.9:
+  pg_data-2.9-13:
   solr_data-2.9:
   redis_data-2.9:
 

--- a/docker-compose-2.9.yml
+++ b/docker-compose-2.9.yml
@@ -31,20 +31,8 @@ services:
       - redis-2.9
       - static-mock-harvest-source-2.9
     command: bash -c "/srv/app/start_ckan_development.sh"
-    # command: bash -c "tail -f /dev/null"
     networks:
       - ckan-2.9
-
-  # db-2.9:
-  #   container_name: db-2.9
-  #   env_file:
-  #     - .env-2.9
-  #   build:
-  #     context: postgresql/
-  #   volumes:
-  #     - pg_data-2.9:/var/lib/postgresql/data
-  #   networks:
-  #     - ckan-2.9
 
   db-2.9-13:
     container_name: db-2.9-13
@@ -105,7 +93,6 @@ services:
 
 volumes:
   ckan_storage-2.9:
-  # pg_data-2.9:
   pg_data-2.9-13:
   solr_data-2.9:
   redis_data-2.9:

--- a/postgresql/Dockerfile.13
+++ b/postgresql/Dockerfile.13
@@ -1,0 +1,13 @@
+FROM postgis/postgis:13-3.1-alpine
+
+# Allow connections; we don't map out any ports so only linked docker containers can connect
+RUN echo "host all  all    0.0.0.0/0  md5" >> /var/lib/postgresql/data/pg_hba.conf
+
+# Customize default user/pass/db
+ENV POSTGRES_DB ckan
+ENV POSTGRES_USER ckan
+ARG POSTGRES_PASSWORD
+ARG DATASTORE_READONLY_PASSWORD
+
+# Include extra setup scripts (eg datastore)
+ADD docker-entrypoint-initdb.d /docker-entrypoint-initdb.d


### PR DESCRIPTION
## What

Add postgres 13 as an option to run CKAN 2.9 against. 

I've left postgres 9 in place for now in case there's a need to compare how postgres 9 was handling data vs 13.

## Reference 

https://trello.com/c/0LN3n9Aa/2-ckan