### PR TITLE
Use opensearch rather than elasticsearch for docker ckan 2.9 full stack

### DIFF
--- a/docker-compose-2.9-full.yml
+++ b/docker-compose-2.9-full.yml
@@ -1,22 +1,20 @@
 version: "3"
 
 services:
-  elasticsearch-2.9:
-    container_name: elasticsearch-2.9
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.9.1
+  opensearch-2.9:
+    container_name: opensearch-2.9
+    image: opensearchproject/opensearch
     environment:
-      - node.name=elasticsearch
-      - discovery.type=single-node
-      - bootstrap.memory_lock=true
-      - "ES_JAVA_OPTS=-Xms1g -Xmx1g"
-    ulimits:
-      memlock:
-        soft: -1
-        hard: -1
+      - bootstrap.memory_lock=true # along with the memlock settings below, disables swapping
+      - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m" # minimum and maximum Java heap size, recommend setting both to 50% of system RAM
+      - "DISABLE_INSTALL_DEMO_CONFIG=true" # disables execution of install_demo_configuration.sh bundled with security plugin, which installs demo certificates and security configurations to OpenSearch
+      - "DISABLE_SECURITY_PLUGIN=true" # disables security plugin entirely in OpenSearch by setting plugins.security.disabled: true in opensearch.yml
+      - "discovery.type=single-node"
     volumes:
-      - es_data-2.9:/usr/share/elasticsearch/data
+      - os_data-2.9:/usr/share/opensearch/data
     ports:
       - 9202:9200
+      - 9602:9600
     networks:
       - ckan-2.9
 
@@ -28,13 +26,13 @@ services:
     env_file:
       - .env-2.9
     links:
-      - db-2.9:db
-      - elasticsearch-2.9:elasticsearch
+      - db-2.9-13:db
+      - opensearch-2.9:elasticsearch
       - redis-2.9:redis
       - ckan-postdev-2.9:ckan-postdev
     depends_on: 
-      - db-2.9
-      - elasticsearch-2.9
+      - db-2.9-13
+      - opensearch-2.9
       - redis-2.9
     command: bash -c "./bin/setup-docker.sh"
     volumes:
@@ -46,14 +44,14 @@ services:
   find-2.9:
     image: govuk/find:latest
     container_name: find-2.9
-    build:
+    build:  
       context: ./src/2.9/datagovuk_find/
     env_file:
       - .env-2.9
     links:
-      - elasticsearch-2.9:elasticsearch
+      - opensearch-2.9:elasticsearch
     depends_on: 
-      - elasticsearch-2.9
+      - opensearch-2.9
     command: bash -c "./bin/setup-docker.sh"
     volumes:
       - ./src/2.9/datagovuk_find:/srv/app/datagovuk_find
@@ -64,7 +62,7 @@ services:
       - "4002:3000"
 
 volumes:
-  es_data-2.9:
+  os_data-2.9:
 
 networks:
     ckan-2.9:


### PR DESCRIPTION
PaaS no longer supports elasticsearch, it has been instead replaced by opensearch which can be directly swapped in, so update it to closely match what is deployed in production.